### PR TITLE
docs: Add bootstrap quickstart to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,29 @@ AgentReady evaluates your repository across multiple dimensions of code quality,
 
 ## Quick Start
 
+### Bootstrap (Recommended)
+
+Transform your repository with one command:
+
+```bash
+cd /path/to/your/repo
+agentready bootstrap .
+git add . && git commit -m "build: Bootstrap agent-ready infrastructure"
+git push
+```
+
+**What you get:**
+
+- ✅ GitHub Actions workflows (tests, security, AgentReady assessment)
+- ✅ Pre-commit hooks (formatters, linters)
+- ✅ Issue/PR templates
+- ✅ Dependabot configuration
+- ✅ Automated assessment on every PR
+
+**Duration**: <60 seconds
+
+[See detailed Bootstrap tutorial →](docs/user-guide.md#bootstrap-your-repository)
+
 ### Installation
 
 ```bash
@@ -30,7 +53,9 @@ source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 pip install -e ".[dev]"
 ```
 
-### Basic Usage
+### Assessment Only
+
+For one-time analysis without infrastructure changes:
 
 ```bash
 # Assess current repository


### PR DESCRIPTION
## Summary

- Add 'Bootstrap (Recommended)' section as primary Quick Start entry point
- Move existing basic usage to 'Assessment Only' subsection  
- Include 4-line command sequence for copy-paste workflow
- Show value proposition (what you get in <60 seconds)
- Link to detailed tutorial in docs/user-guide.md

## Why This Matters

Bootstrap is AgentReady's killer feature - it transforms repos in <60 seconds with GitHub Actions, pre-commit hooks, templates, and automated assessments. But users landing on README.md don't see it. This PR makes bootstrap the default entry point, maximizing adoption.

## Changes

### Before
- Quick Start section showed only `agentready assess` command
- Bootstrap command buried in docs/user-guide.md

### After  
- Quick Start prioritizes Bootstrap (Recommended) first
- Assessment-only workflow clearly labeled as alternative approach
- Simple 4-line copy-paste for immediate value

## Test Plan

- [x] Verified markdownlint passes (no new issues introduced)
- [x] Confirmed link to docs/user-guide.md is correct
- [x] Reviewed formatting in GitHub markdown preview

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)