### PR TITLE
fix: Correct Assessment field name in demo command

### DIFF
--- a/src/agentready/cli/demo.py
+++ b/src/agentready/cli/demo.py
@@ -489,7 +489,7 @@ def demo(language, no_browser, keep_repo):
             overall_score=overall_score,
             certification_level=certification_level,
             attributes_assessed=assessed,
-            attributes_skipped=skipped,
+            attributes_not_assessed=skipped,
             attributes_total=len(findings),
             findings=findings,
             config=None,


### PR DESCRIPTION
## Summary
Fixes field name inconsistency in the demo command that was causing test failures.

## Changes
- Changed `attributes_skipped` to `attributes_not_assessed` in `demo.py` line 492
- This aligns with the updated Assessment model schema

## Testing
- All 6 demo tests now pass (previously 3 were failing)
- Overall test suite: 100 tests passing
- Current coverage: 61%

## Related Issues
Partially addresses #12 (Improve Test Coverage and Edge Case Handling)

Note: This PR fixes the immediate test failures. Additional work will be tracked in a separate issue for achieving 90% test coverage with CI enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)