### PR TITLE
fix: Prevent XSS in HTML reports (fixes #54)

### DIFF
--- a/src/agentready/reporters/html.py
+++ b/src/agentready/reporters/html.py
@@ -1,6 +1,5 @@
 """HTML reporter for generating interactive assessment reports."""
 
-import json
 from pathlib import Path
 
 from jinja2 import Environment, PackageLoader, select_autoescape
@@ -68,13 +67,15 @@ class HTMLReporter(BaseReporter):
             "duration_seconds": assessment.duration_seconds,
             "config": assessment.config,
             "metadata": assessment.metadata,
-            # Embed assessment JSON for JavaScript
-            "assessment_json": json.dumps(assessment.to_dict()),
+            # Security: Pass dict directly, Jinja2's tojson filter handles escaping
+            # Prevents XSS by avoiding double JSON encoding
+            "assessment_dict": assessment.to_dict(),
             # Theme data
             "theme": theme,
             "theme_name": theme.name,
             "available_themes": available_themes,
-            "available_themes_json": json.dumps(available_themes),
+            # Security: Pass dict, not pre-serialized JSON
+            "available_themes_dict": available_themes,
         }
 
         # Render template

--- a/src/agentready/templates/report.html.j2
+++ b/src/agentready/templates/report.html.j2
@@ -713,11 +713,12 @@
     </div>
 
     <script>
-        // Embedded assessment data (properly escaped to prevent XSS)
-        const ASSESSMENT = JSON.parse({{ assessment_json|tojson }});
+        // Security: Using Jinja2's tojson filter for proper XSS prevention
+        // tojson creates JavaScript objects directly, no JSON.parse() needed
+        const ASSESSMENT = {{ assessment_dict|tojson }};
 
-        // Embedded theme data
-        const THEMES = JSON.parse({{ available_themes_json|tojson }});
+        // Embedded theme data (properly escaped)
+        const THEMES = {{ available_themes_dict|tojson }};
         const DEFAULT_THEME = {{ theme_name|tojson }};
 
         // Theme management with localStorage persistence


### PR DESCRIPTION
## Summary
- Eliminated double JSON encoding (json.dumps + tojson) that could enable XSS
- Use Jinja2's `tojson` filter for proper JavaScript context escaping
- Pass raw dicts to template instead of pre-serialized JSON strings

## Security Impact
- **CVSS Score**: 7.1 (High) → **Resolved**
- **Attack Vector**: Malicious repository metadata (names, paths, URLs) in HTML reports
- **Mitigation**: Single-encoding with Jinja2's safe `tojson` filter

## Changes
- `reporters/html.py:72-79` - Pass `assessment_dict` and `available_themes_dict` (dicts, not JSON strings)
- `reporters/html.py:3` - Removed unused `json` import
- `templates/report.html.j2:716-722` - Use `tojson` directly, remove `JSON.parse()` calls

## Technical Details
**Before (vulnerable)**:
```python
"assessment_json": json.dumps(assessment.to_dict())  # Pre-serialized
```
```javascript
const ASSESSMENT = JSON.parse({{ assessment_json|tojson }});  // Double encoding
```

**After (secure)**:
```python
"assessment_dict": assessment.to_dict()  # Raw dict
```
```javascript
const ASSESSMENT = {{ assessment_dict|tojson }};  // Single safe encoding
```

## Testing
- All linters passed (black, isort, ruff)
- Jinja2 autoescape enabled + tojson filter provides comprehensive XSS protection
- Follow-up: Manual testing of HTML report generation

## Related Issues
Fixes #54

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)