### PR TITLE
fix: Correct datetime import pattern in RepomixService

### DIFF
--- a/src/agentready/services/repomix.py
+++ b/src/agentready/services/repomix.py
@@ -1,9 +1,9 @@
 """Repomix integration service for generating AI-friendly repository context."""
 
-import datetime
 import json
 import shutil
 import subprocess
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -257,7 +257,7 @@ class RepomixService:
 
         # Check most recent file
         newest_file = max(output_files, key=lambda p: p.stat().st_mtime)
-        age_seconds = datetime.datetime.now().timestamp() - newest_file.stat().st_mtime
+        age_seconds = datetime.now().timestamp() - newest_file.stat().st_mtime
         age_days = age_seconds / (24 * 3600)
 
         if age_days > max_age_days:


### PR DESCRIPTION
## Summary
- Changed from module-level `import datetime` to `from datetime import datetime`
- Updated usage from `datetime.datetime.now()` to `datetime.now()`
- Improves code readability and follows Python conventions

## Priority
**P1 - HIGH** (Code Quality)

## Changes
- `repomix.py:6` - Import change: `from datetime import datetime`
- `repomix.py:260` - Usage update: `datetime.now()`

## Code Comparison

**Before**:
```python
import datetime

# ... 250 lines later ...
age_seconds = datetime.datetime.now().timestamp() - newest_file.stat().st_mtime
```

**After**:
```python
from datetime import datetime

# ... 250 lines later ...
age_seconds = datetime.now().timestamp() - newest_file.stat().st_mtime
```

## Benefits
1. **Readability**: Shorter, cleaner syntax
2. **Consistency**: Matches project import patterns
3. **Convention**: Follows Python best practices for datetime usage
4. **Maintenance**: Reduces redundant module prefix

## Testing
- All linters passed (black, isort, ruff)
- No functional changes - pure refactoring
- RepomixService behavior unchanged

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)