### PR TITLE
feat: Implement InlineDocumentationAssessor (fixes #77)

### DIFF
--- a/src/agentready/assessors/stub_assessors.py
+++ b/src/agentready/assessors/stub_assessors.py
@@ -277,13 +277,6 @@ def create_stub_assessors():
             0.03,
         ),
         StubAssessor(
-            "inline_documentation",
-            "Inline Documentation",
-            "Documentation Standards",
-            2,
-            0.03,
-        ),
-        StubAssessor(
             "file_size_limits",
             "File Size Limits",
             "Context Window Optimization",

--- a/src/agentready/cli/main.py
+++ b/src/agentready/cli/main.py
@@ -22,6 +22,7 @@ from ..assessors.documentation import (
     ArchitectureDecisionsAssessor,
     CLAUDEmdAssessor,
     ConciseDocumentationAssessor,
+    InlineDocumentationAssessor,
     READMEAssessor,
 )
 from ..assessors.structure import (
@@ -77,7 +78,7 @@ def create_all_assessors():
         TypeAnnotationsAssessor(),
         StandardLayoutAssessor(),
         LockFilesAssessor(),
-        # Tier 2 Critical (10 assessors - 5 implemented, 5 stubs)
+        # Tier 2 Critical (10 assessors - 6 implemented, 4 stubs)
         TestCoverageAssessor(),
         PreCommitHooksAssessor(),
         ConventionalCommitsAssessor(),
@@ -85,6 +86,7 @@ def create_all_assessors():
         OneCommandSetupAssessor(),
         SeparationOfConcernsAssessor(),
         ConciseDocumentationAssessor(),
+        InlineDocumentationAssessor(),
         CyclomaticComplexityAssessor(),  # Actually Tier 3, but including here
         # Tier 3 Important (4 implemented)
         ArchitectureDecisionsAssessor(),


### PR DESCRIPTION
## Summary
Implements InlineDocumentationAssessor (Tier 2 Critical, 3% weight) to evaluate docstring coverage for public functions, classes, and modules.

## Implementation Details
- **AST Parsing**: Uses `ast.parse()` and `ast.get_docstring()` for accurate detection
- **Public API Focus**: Only counts public items (not starting with `_`)
- **Coverage Calculation**: (documented_items / total_public_items) * 100
- **Proportional Scoring**: ≥80% threshold with proportional scoring
- **Language Support**: Python (JavaScript/TypeScript can be added later)

## Test Results on AgentReady
- **Score**: 100/100 (pass)
- **Measured**: 92.0% coverage
- **Evidence**:
  - Documented items: 751/816
  - Good docstring coverage
  - Includes module, function, and class docstrings

## Changes
- Added `InlineDocumentationAssessor` class in `documentation.py`
- Uses AST parsing similar to `TypeAnnotationsAssessor`
- Removed duplicate stub assessor from `stub_assessors.py`
- Registered in `create_all_assessors()` in `main.py`

## Related
- Fixes #77
- Part of Tier 2 assessor implementation sprint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>