### PR TITLE
feat: Implement OpenAPISpecsAssessor (fixes #80)

### DIFF
--- a/src/agentready/assessors/stub_assessors.py
+++ b/src/agentready/assessors/stub_assessors.py
@@ -299,13 +299,6 @@ def create_stub_assessors():
         ),
         # Tier 3 Important
         StubAssessor(
-            "openapi_specs",
-            "OpenAPI/Swagger Specifications",
-            "API Documentation",
-            3,
-            0.03,
-        ),
-        StubAssessor(
             "architecture_decisions",
             "Architecture Decision Records",
             "Documentation Standards",

--- a/src/agentready/cli/main.py
+++ b/src/agentready/cli/main.py
@@ -25,6 +25,7 @@ from ..assessors.documentation import (
     CLAUDEmdAssessor,
     ConciseDocumentationAssessor,
     InlineDocumentationAssessor,
+    OpenAPISpecsAssessor,
     READMEAssessor,
 )
 from ..assessors.structure import (
@@ -90,12 +91,13 @@ def create_all_assessors():
         ConciseDocumentationAssessor(),
         InlineDocumentationAssessor(),
         CyclomaticComplexityAssessor(),  # Actually Tier 3, but including here
-        # Tier 3 Important (6 implemented)
+        # Tier 3 Important (7 implemented)
         ArchitectureDecisionsAssessor(),
         IssuePRTemplatesAssessor(),
         CICDPipelineVisibilityAssessor(),
         SemanticNamingAssessor(),
         StructuredLoggingAssessor(),
+        OpenAPISpecsAssessor(),
     ]
 
     # Add remaining stub assessors


### PR DESCRIPTION
Implements Tier 3 Important assessor for OpenAPI/Swagger specifications.

**Changes**:
- Add OpenAPISpecsAssessor with smart web API detection via framework indicators
- Scoring: 60% file presence, 20% OpenAPI 3.x version, 20% completeness (paths + schemas)
- Support for both OpenAPI 3.x and Swagger 2.0 specs (YAML/JSON)
- Returns not_applicable for non-API projects (CLI tools, libraries)
- Parse specs to extract version, paths, schemas for quality scoring
- Comprehensive remediation with validation commands and examples
- Remove duplicate openapi_specs stub from stub_assessors.py

**Test Results**:
- AgentReady (CLI tool) correctly returns not_applicable
- All linters passed (black, isort, ruff)
- Assessment runs successfully (18/30 assessed)

**Closes**: #80