### PR TITLE
feat: Implement BranchProtectionAssessor stub (fixes #86)

### DIFF
--- a/src/agentready/assessors/testing.py
+++ b/src/agentready/assessors/testing.py
@@ -642,3 +642,41 @@ jobs:
                 ),
             ],
         )
+
+
+class BranchProtectionAssessor(BaseAssessor):
+    """Assesses branch protection rules on main/production branches.
+
+    Tier 4 Advanced (0.5% weight) - Requires GitHub API access to check
+    branch protection settings. This is a stub implementation that will
+    return not_applicable until GitHub API integration is implemented.
+    """
+
+    @property
+    def attribute_id(self) -> str:
+        return "branch_protection"
+
+    @property
+    def tier(self) -> int:
+        return 4  # Advanced
+
+    @property
+    def attribute(self) -> Attribute:
+        return Attribute(
+            id=self.attribute_id,
+            name="Branch Protection Rules",
+            category="Git & Version Control",
+            tier=self.tier,
+            description="Required status checks and review approvals before merging",
+            criteria="Branch protection enabled with status checks and required reviews",
+            default_weight=0.005,
+        )
+
+    def assess(self, repository: Repository) -> Finding:
+        """Stub implementation - requires GitHub API integration."""
+        return Finding.not_applicable(
+            self.attribute,
+            reason="Requires GitHub API integration for branch protection checks. "
+            "Future implementation will verify: required status checks, "
+            "required reviews, force push prevention, and branch update requirements.",
+        )

--- a/src/agentready/cli/main.py
+++ b/src/agentready/cli/main.py
@@ -41,6 +41,7 @@ from ..assessors.stub_assessors import (
     create_stub_assessors,
 )
 from ..assessors.testing import (
+    BranchProtectionAssessor,
     CICDPipelineVisibilityAssessor,
     PreCommitHooksAssessor,
     TestCoverageAssessor,
@@ -98,6 +99,8 @@ def create_all_assessors():
         SemanticNamingAssessor(),
         StructuredLoggingAssessor(),
         OpenAPISpecsAssessor(),
+        # Tier 4 Advanced (1 stub)
+        BranchProtectionAssessor(),
     ]
 
     # Add remaining stub assessors


### PR DESCRIPTION
Implements Tier 4 stub assessor for branch protection rules.

**Changes**:
- Add BranchProtectionAssessor as proper stub implementation
- Tier 4 Advanced (0.5% weight) - requires GitHub API integration  
- Returns not_applicable with clear explanation about requirements
- Provides path for future GitHub API integration

**Stub Reasoning**:
This assessor requires GitHub API access to query branch protection rules. Full implementation would check:
- Required status checks on main/master branches
- Required review approvals before merge
- Force push prevention settings
- Branch update requirements (must be up to date)

**Test Results**:
- AgentReady correctly returns not_applicable
- All linters passed (black, isort, ruff)
- Assessment runs successfully (18/31 assessed)

**Closes**: #86