### PR TITLE
feat: Auto-sync CLAUDE.md during semantic-release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -12,7 +12,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "sed -i 's/version = \".*\"/version = \"${nextRelease.version}\"/' pyproject.toml"
+        "prepareCmd": "sed -i 's/version = \".*\"/version = \"${nextRelease.version}\"/' pyproject.toml && bash scripts/sync-claude-md.sh ${nextRelease.version}"
       }
     ],
     [
@@ -29,7 +29,7 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md", "pyproject.toml"],
+        "assets": ["CHANGELOG.md", "pyproject.toml", "CLAUDE.md"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]

--- a/scripts/sync-claude-md.sh
+++ b/scripts/sync-claude-md.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Sync CLAUDE.md with current project metrics
+# Used by semantic-release during the release process
+
+set -e
+
+VERSION=${1:-$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')}
+TODAY=$(date +%Y-%m-%d)
+
+echo "Syncing CLAUDE.md to version $VERSION (date: $TODAY)"
+
+# Update all version numbers (simpler regex that works across different sed versions)
+sed -i.bak "s/v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*/v$VERSION/g" CLAUDE.md
+sed -i.bak "s/\*\*AgentReady Version\*\*: [0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*/\*\*AgentReady Version\*\*: $VERSION/" CLAUDE.md
+
+# Update "Last Updated" date at top (first occurrence only)
+awk -v today="$TODAY" '
+  !updated && /\*\*Last Updated\*\*:/ {
+    sub(/[0-9]{4}-[0-9]{2}-[0-9]{2}/, today);
+    updated=1
+  }
+  {print}
+' CLAUDE.md > CLAUDE.md.tmp && mv CLAUDE.md.tmp CLAUDE.md
+
+# Update "Last Updated" date at bottom (second occurrence)
+awk -v today="$TODAY" '
+  /\*\*Last Updated\*\*:.*by Jeremy Eder/ {
+    sub(/[0-9]{4}-[0-9]{2}-[0-9]{2}/, today);
+  }
+  {print}
+' CLAUDE.md > CLAUDE.md.tmp && mv CLAUDE.md.tmp CLAUDE.md
+
+# Try to extract self-assessment score (if examples exist)
+if [ -f "examples/self-assessment/assessment-latest.json" ]; then
+  SCORE=$(python3 -c "
+import json
+try:
+    with open('examples/self-assessment/assessment-latest.json') as f:
+        data = json.load(f)
+        print(f\"{data['overall_score']}\")
+except Exception as e:
+    print('unknown', file=sys.stderr)
+    exit(1)
+" 2>/dev/null || echo "")
+
+  if [ -n "$SCORE" ] && [ "$SCORE" != "unknown" ]; then
+    echo "Updating self-assessment score to $SCORE"
+    # Update self-assessment scores (match any number with optional decimal)
+    sed -i.bak "s/[0-9][0-9]*\.[0-9][0-9]*\/100/$SCORE\/100/g" CLAUDE.md
+  fi
+fi
+
+# Clean up backup files
+rm -f CLAUDE.md.bak
+
+echo "✓ CLAUDE.md synced successfully"
+echo "  - Version: $VERSION"
+echo "  - Date: $TODAY"
+if [ -n "$SCORE" ]; then
+  echo "  - Self-Assessment: $SCORE/100"
+fi


### PR DESCRIPTION
## Summary

Automates CLAUDE.md updates as part of the release workflow, ensuring documentation always reflects the current version. This eliminates the 23-version drift problem we discovered in PR #100.

## How It Works

**Release Flow** (automated):
1. Semantic-release determines next version
2. Updates `pyproject.toml` version
3. **NEW**: Executes `scripts/sync-claude-md.sh` with new version
4. Script updates CLAUDE.md:
   - Version numbers (Current Status + bottom footer)
   - Last Updated dates (both occurrences)
   - Self-assessment score (from `examples/self-assessment/assessment-latest.json`)
5. Both files committed together in release commit

## Changes

### `scripts/sync-claude-md.sh` (New)
Standalone bash script that:
- Accepts version as argument (from semantic-release)
- Updates all version references using simple sed patterns
- Updates both "Last Updated" dates to today
- Optionally updates self-assessment score if JSON exists
- Works across different sed implementations (macOS/Linux)

### `.releaserc.json` (Modified)
- Added sync script execution to `@semantic-release/exec` prepareCmd
- Added `CLAUDE.md` to `@semantic-release/git` assets array
- Ensures atomic commits (version + docs together)

## Testing

Verified locally on main branch:
```bash
$ bash scripts/sync-claude-md.sh 1.24.0
Syncing CLAUDE.md to version 1.24.0 (date: 2025-11-22)
Updating self-assessment score to 80.0
✓ CLAUDE.md synced successfully
  - Version: 1.24.0
  - Date: 2025-11-22
  - Self-Assessment: 80.0/100
```

All fields updated correctly:
- ✅ **Current Status**: v1.0.0 → v1.24.0
- ✅ **AgentReady Version**: 1.0.0 → 1.24.0
- ✅ **Self-Assessment**: 75.4/100 → 80.0/100
- ✅ **Last Updated**: 2025-11-21 → 2025-11-22 (both occurrences)

## Benefits

1. **Zero Manual Effort**: Happens automatically on every release
2. **Eliminates Drift**: Version and docs always in sync
3. **Auditable**: All updates tracked in release commits
4. **Self-Healing**: Score updates when new assessments run
5. **Platform Agnostic**: Works on macOS and Linux (GitHub Actions)

## Impact

**Before**: 23-version drift (v1.0.0 documented, v1.23.0 actual)
**After**: Perfect sync on every release

## Next Release

On the next semantic-release run, you'll see:
```
chore(release): 1.24.0 [skip ci]

<release notes>

Files updated:
- CHANGELOG.md
- pyproject.toml
- CLAUDE.md  ← NEW!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)