### PR TITLE
feat: Phase 2 multi-repository assessment reporting

### DIFF
--- a/src/agentready/reporters/aggregated_json.py
+++ b/src/agentready/reporters/aggregated_json.py
@@ -1,0 +1,40 @@
+"""Aggregated JSON reporter for batch assessments."""
+
+import json
+from pathlib import Path
+
+from ..models.batch_assessment import BatchAssessment
+
+
+class AggregatedJSONReporter:
+    """Generates single JSON file with all batch assessment data.
+
+    Structure:
+    - schema_version: Data format version
+    - batch_id: Unique identifier for this batch
+    - timestamp: When batch started
+    - summary: Aggregated statistics
+    - results: Individual repository results (including assessments)
+    - total_duration_seconds: Total time for entire batch
+    - agentready_version: Version used for assessment
+    """
+
+    def generate(self, batch_assessment: BatchAssessment, output_path: Path) -> Path:
+        """Generate aggregated JSON file.
+
+        Args:
+            batch_assessment: Complete batch assessment with all results
+            output_path: Path where JSON file should be saved
+
+        Returns:
+            Path to generated JSON file
+
+        Raises:
+            IOError: If JSON cannot be written
+        """
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(batch_assessment.to_dict(), f, indent=2, default=str)
+
+        return output_path

--- a/src/agentready/reporters/csv_reporter.py
+++ b/src/agentready/reporters/csv_reporter.py
@@ -1,0 +1,151 @@
+"""CSV reporter for generating tabular assessment reports.
+
+SECURITY: Implements CSV formula injection prevention (CWE-1236).
+"""
+
+import csv
+from pathlib import Path
+from typing import Any
+
+from ..models.batch_assessment import BatchAssessment
+
+
+class CSVReporter:
+    """Generates CSV/TSV summary reports for batch assessments.
+
+    SECURITY REQUIREMENT: Must escape CSV formula injection characters
+    (=, +, -, @, tab, newline) to prevent malicious payloads from executing
+    in spreadsheet applications like Excel.
+
+    References:
+    - OWASP: https://owasp.org/www-community/attacks/CSV_Injection
+    - CWE-1236: Improper Neutralization of Formula Elements in a CSV File
+    """
+
+    # SECURITY: Characters that trigger formula execution in spreadsheet apps
+    FORMULA_CHARS = {"=", "+", "-", "@", "\t", "\r"}
+
+    @staticmethod
+    def sanitize_csv_field(value: Any) -> str:
+        """Escape fields that could be interpreted as formulas.
+
+        SECURITY: Prevents CSV injection (CWE-1236) by prefixing
+        formula-triggering characters with a single quote. This causes
+        spreadsheet applications to treat the value as literal text.
+
+        Args:
+            value: Any value to be written to CSV
+
+        Returns:
+            Sanitized string safe for CSV output
+
+        Examples:
+            >>> CSVReporter.sanitize_csv_field("=1+1")
+            "'=1+1"
+            >>> CSVReporter.sanitize_csv_field("normal text")
+            "normal text"
+            >>> CSVReporter.sanitize_csv_field(None)
+            ""
+        """
+        if value is None:
+            return ""
+
+        str_value = str(value)
+
+        # Prefix formula-triggering fields with single quote
+        if str_value and str_value[0] in CSVReporter.FORMULA_CHARS:
+            return f"'{str_value}"
+
+        return str_value
+
+    def generate(
+        self, batch_assessment: BatchAssessment, output_path: Path, delimiter: str = ","
+    ) -> Path:
+        """Generate CSV with one row per repository.
+
+        Columns:
+        - repo_url: Repository URL or path
+        - repo_name: Repository name
+        - overall_score: Numeric score (0-100)
+        - certification_level: Bronze/Silver/Gold/Platinum/Needs Improvement
+        - primary_language: Primary detected language
+        - timestamp: Assessment timestamp (ISO 8601)
+        - duration_seconds: Time taken to assess
+        - cached: Whether result came from cache
+
+        Args:
+            batch_assessment: Complete batch assessment with results
+            output_path: Path where CSV file should be saved
+            delimiter: Field delimiter (default: comma, use tab for TSV)
+
+        Returns:
+            Path to generated CSV file
+
+        Raises:
+            IOError: If CSV cannot be written
+        """
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(output_path, "w", newline="", encoding="utf-8") as f:
+            # Define columns
+            fieldnames = [
+                "repo_url",
+                "repo_name",
+                "overall_score",
+                "certification_level",
+                "primary_language",
+                "timestamp",
+                "duration_seconds",
+                "cached",
+                "status",
+                "error_type",
+                "error_message",
+            ]
+
+            writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter=delimiter)
+            writer.writeheader()
+
+            # Write successful assessments
+            for result in batch_assessment.results:
+                if result.is_success():
+                    assessment = result.assessment
+                    # SECURITY: Sanitize all string fields
+                    row = {
+                        "repo_url": self.sanitize_csv_field(result.repository_url),
+                        "repo_name": self.sanitize_csv_field(assessment.repository.name),
+                        "overall_score": assessment.overall_score,
+                        "certification_level": self.sanitize_csv_field(
+                            assessment.certification_level
+                        ),
+                        "primary_language": self.sanitize_csv_field(
+                            assessment.repository.primary_language
+                        ),
+                        "timestamp": assessment.timestamp.isoformat(),
+                        "duration_seconds": result.duration_seconds,
+                        "cached": result.cached,
+                        "status": "success",
+                        "error_type": "",
+                        "error_message": "",
+                    }
+                    writer.writerow(row)
+
+            # Write failed assessments
+            for result in batch_assessment.results:
+                if not result.is_success():
+                    # SECURITY: Sanitize all string fields
+                    row = {
+                        "repo_url": self.sanitize_csv_field(result.repository_url),
+                        "repo_name": "",
+                        "overall_score": 0,
+                        "certification_level": "",
+                        "primary_language": "",
+                        "timestamp": "",
+                        "duration_seconds": result.duration_seconds,
+                        "cached": False,
+                        "status": "failed",
+                        "error_type": self.sanitize_csv_field(result.error_type),
+                        "error_message": self.sanitize_csv_field(result.error),
+                    }
+                    writer.writerow(row)
+
+        return output_path

--- a/src/agentready/reporters/json_reporter.py
+++ b/src/agentready/reporters/json_reporter.py
@@ -1,0 +1,38 @@
+"""JSON reporter for generating machine-readable assessment reports."""
+
+import json
+from pathlib import Path
+
+from ..models.assessment import Assessment
+from .base import BaseReporter
+
+
+class JSONReporter(BaseReporter):
+    """Generates JSON reports from individual assessments.
+
+    Features:
+    - Schema versioning for backwards compatibility
+    - Complete assessment data including findings and remediation
+    - Machine-readable for automation and tooling
+    - ISO 8601 timestamps for unambiguous dates
+    """
+
+    def generate(self, assessment: Assessment, output_path: Path) -> Path:
+        """Generate JSON report from assessment data.
+
+        Args:
+            assessment: Complete assessment with findings
+            output_path: Path where JSON file should be saved
+
+        Returns:
+            Path to generated JSON file
+
+        Raises:
+            IOError: If JSON cannot be written
+        """
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(assessment.to_dict(), f, indent=2, default=str)
+
+        return output_path

--- a/src/agentready/reporters/multi_html.py
+++ b/src/agentready/reporters/multi_html.py
@@ -1,0 +1,108 @@
+"""Multi-repository HTML reporter for batch assessment summaries.
+
+SECURITY: Implements comprehensive XSS prevention through:
+- Jinja2 autoescape
+- URL validation and sanitization
+- Content Security Policy headers
+"""
+
+import html
+from pathlib import Path
+from urllib.parse import urlparse
+
+import jinja2
+
+from ..models.batch_assessment import BatchAssessment
+
+
+class MultiRepoHTMLReporter:
+    """Generates summary HTML report for batch assessments.
+
+    SECURITY REQUIREMENTS:
+    - Jinja2 autoescape MUST be enabled (prevents XSS)
+    - All repository metadata MUST be HTML-escaped
+    - CSP header MUST be included (prevents script injection)
+    - URLs MUST be validated (only http/https allowed)
+
+    References:
+    - OWASP XSS Prevention: https://owasp.org/www-community/attacks/xss/
+    - CWE-79: Improper Neutralization of Input During Web Page Generation
+    """
+
+    def __init__(self, template_dir: Path):
+        """Initialize reporter with Jinja2 environment.
+
+        Args:
+            template_dir: Directory containing Jinja2 templates
+
+        SECURITY: Autoescape is ENABLED by default for HTML/XML files.
+        """
+        # SECURITY: Enable autoescape to prevent XSS
+        self.env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(str(template_dir)),
+            autoescape=jinja2.select_autoescape(["html", "xml", "j2"]),
+        )
+
+        # Register security filters
+        self.env.filters["sanitize_url"] = self.sanitize_url
+
+    @staticmethod
+    def sanitize_url(url: str) -> str:
+        """Validate and sanitize URLs for safe HTML rendering.
+
+        SECURITY: Only allow http/https schemes. Prevents javascript:,
+        data:, file:, and other potentially malicious URL schemes.
+
+        Args:
+            url: URL to sanitize
+
+        Returns:
+            HTML-escaped URL if valid, empty string otherwise
+
+        Examples:
+            >>> MultiRepoHTMLReporter.sanitize_url("https://github.com/user/repo")
+            "https://github.com/user/repo"
+            >>> MultiRepoHTMLReporter.sanitize_url("javascript:alert(1)")
+            ""
+        """
+        if not url:
+            return ""
+
+        try:
+            parsed = urlparse(url)
+            # SECURITY: Only allow http/https schemes
+            if parsed.scheme not in ("http", "https", ""):
+                return ""
+            # SECURITY: HTML-escape the URL to prevent attribute injection
+            return html.escape(url, quote=True)
+        except Exception:
+            # Failed to parse - treat as unsafe
+            return ""
+
+    def generate(self, batch_assessment: BatchAssessment, output_path: Path) -> Path:
+        """Generate summary HTML report for batch assessment.
+
+        Args:
+            batch_assessment: Complete batch assessment with all results
+            output_path: Path where HTML file should be saved
+
+        Returns:
+            Path to generated HTML file
+
+        Raises:
+            IOError: If HTML cannot be written
+        """
+        template = self.env.get_template("multi_report.html.j2")
+
+        # Render template with assessment data
+        # SECURITY: Jinja2 autoescape handles all variable escaping
+        html_content = template.render(
+            batch_assessment=batch_assessment,
+            timestamp=batch_assessment.timestamp.isoformat(),
+        )
+
+        # Write to file
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(html_content, encoding="utf-8")
+
+        return output_path

--- a/src/agentready/templates/multi_report.html.j2
+++ b/src/agentready/templates/multi_report.html.j2
@@ -1,0 +1,369 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    {# SECURITY: CSP header prevents inline scripts and external resources #}
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'self'; script-src 'none'; object-src 'none'; style-src 'unsafe-inline';">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Multi-Repository Assessment Report</title>
+    <style>
+        :root {
+            --color-primary: #4CAF50;
+            --color-bg: #f5f5f5;
+            --color-card: #ffffff;
+            --color-border: #ddd;
+            --color-text: #333;
+            --color-text-light: #666;
+            --color-platinum: linear-gradient(to right, #BCC6CC, #E5E4E2);
+            --color-gold: linear-gradient(to right, #FFD700, #FFA500);
+            --color-silver: linear-gradient(to right, #C0C0C0, #A8A8A8);
+            --color-bronze: linear-gradient(to right, #CD7F32, #B8733C);
+            --color-error: #f44336;
+            --color-error-bg: #FFEBEE;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            line-height: 1.6;
+            color: var(--color-text);
+            background-color: var(--color-bg);
+            padding: 2rem;
+        }
+
+        .container {
+            max-width: 1400px;
+            margin: 0 auto;
+            background: var(--color-card);
+            padding: 2rem;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }
+
+        h1 {
+            color: var(--color-text);
+            border-bottom: 3px solid var(--color-primary);
+            padding-bottom: 0.5rem;
+            margin-bottom: 1rem;
+        }
+
+        h2 {
+            color: #555;
+            margin-top: 2rem;
+            margin-bottom: 1rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 2px solid #eee;
+        }
+
+        .timestamp {
+            color: var(--color-text-light);
+            font-size: 0.875rem;
+            margin-bottom: 2rem;
+        }
+
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 1rem;
+            margin: 1.5rem 0;
+        }
+
+        .stat-card {
+            background: #f9f9f9;
+            padding: 1.25rem;
+            border-radius: 6px;
+            border-left: 4px solid var(--color-primary);
+        }
+
+        .stat-label {
+            font-size: 0.875rem;
+            color: var(--color-text-light);
+            margin-bottom: 0.5rem;
+        }
+
+        .stat-value {
+            font-size: 2rem;
+            font-weight: bold;
+            color: var(--color-text);
+        }
+
+        .cert-list, .lang-list, .attr-list {
+            list-style: none;
+            padding: 0;
+        }
+
+        .cert-list li, .lang-list li, .attr-list li {
+            padding: 0.5rem 0;
+            border-bottom: 1px solid #eee;
+        }
+
+        .cert-list li:last-child, .lang-list li:last-child, .attr-list li:last-child {
+            border-bottom: none;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1.5rem 0;
+            background: var(--color-card);
+        }
+
+        th, td {
+            border: 1px solid var(--color-border);
+            padding: 0.875rem;
+            text-align: left;
+        }
+
+        th {
+            background-color: var(--color-primary);
+            color: white;
+            font-weight: 600;
+            position: sticky;
+            top: 0;
+        }
+
+        tr:nth-child(even) {
+            background-color: #f9f9f9;
+        }
+
+        tr:hover {
+            background-color: #f0f0f0;
+        }
+
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.75rem;
+            border-radius: 4px;
+            font-weight: 600;
+            font-size: 0.875rem;
+        }
+
+        .platinum {
+            background: var(--color-platinum);
+            color: #4A4A4A;
+        }
+
+        .gold {
+            background: var(--color-gold);
+            color: #3D2817;
+        }
+
+        .silver {
+            background: var(--color-silver);
+            color: #4A4A4A;
+        }
+
+        .bronze {
+            background: var(--color-bronze);
+            color: #fff;
+        }
+
+        .needs-improvement {
+            background: var(--color-error-bg);
+            color: var(--color-error);
+        }
+
+        a {
+            color: #2196F3;
+            text-decoration: none;
+            transition: color 0.2s;
+        }
+
+        a:hover {
+            text-decoration: underline;
+            color: #1976D2;
+        }
+
+        .error-table {
+            border-left: 4px solid var(--color-error);
+        }
+
+        .error-table th {
+            background-color: var(--color-error);
+        }
+
+        .truncate {
+            max-width: 400px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .no-data {
+            text-align: center;
+            padding: 2rem;
+            color: var(--color-text-light);
+            font-style: italic;
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            .container {
+                padding: 1rem;
+            }
+
+            .stats {
+                grid-template-columns: 1fr;
+            }
+
+            table {
+                font-size: 0.875rem;
+            }
+
+            th, td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🚀 Multi-Repository Assessment Report</h1>
+        <p class="timestamp">Generated: {{ timestamp }}</p>
+
+        <h2>📊 Summary Statistics</h2>
+        <div class="stats">
+            <div class="stat-card">
+                <div class="stat-label">Total Repositories</div>
+                <div class="stat-value">{{ batch_assessment.summary.total_repositories }}</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-label">Successful Assessments</div>
+                <div class="stat-value">{{ batch_assessment.summary.successful_assessments }}</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-label">Failed Assessments</div>
+                <div class="stat-value">{{ batch_assessment.summary.failed_assessments }}</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-label">Average Score</div>
+                <div class="stat-value">{{ "%.1f"|format(batch_assessment.summary.average_score) }}</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-label">Success Rate</div>
+                <div class="stat-value">{{ "%.1f"|format(batch_assessment.get_success_rate()) }}%</div>
+            </div>
+        </div>
+
+        {% if batch_assessment.summary.score_distribution %}
+        <h2>🏆 Certification Distribution</h2>
+        <ul class="cert-list">
+        {% for cert, count in batch_assessment.summary.score_distribution.items() %}
+            {% if count > 0 %}
+            <li>
+                <span class="badge {{ cert.lower().replace(' ', '-') }}">{{ cert }}</span>
+                <strong>{{ count }}</strong> {{ 'repository' if count == 1 else 'repositories' }}
+            </li>
+            {% endif %}
+        {% endfor %}
+        </ul>
+        {% endif %}
+
+        {% if batch_assessment.summary.language_breakdown %}
+        <h2>💻 Language Distribution</h2>
+        <ul class="lang-list">
+        {% for lang, count in batch_assessment.summary.language_breakdown.items() | sort(attribute='1', reverse=true) %}
+            <li><strong>{{ lang }}</strong>: {{ count }} {{ 'repository' if count == 1 else 'repositories' }}</li>
+        {% endfor %}
+        </ul>
+        {% endif %}
+
+        {% if batch_assessment.summary.top_failing_attributes %}
+        <h2>⚠️ Top Failing Attributes</h2>
+        <ul class="attr-list">
+        {% for item in batch_assessment.summary.top_failing_attributes[:10] %}
+            <li>
+                <strong>{{ item['attribute_id'] }}</strong>:
+                {{ item['failure_count'] }} {{ 'failure' if item['failure_count'] == 1 else 'failures' }}
+            </li>
+        {% endfor %}
+        </ul>
+        {% endif %}
+
+        <h2>📋 Repository Results</h2>
+        {% if batch_assessment.results %}
+        <table>
+            <thead>
+                <tr>
+                    <th>Repository</th>
+                    <th>Score</th>
+                    <th>Certification</th>
+                    <th>Language</th>
+                    <th>Duration</th>
+                    <th>Reports</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for result in batch_assessment.results %}
+                {% if result.is_success() %}
+                <tr>
+                    {# SECURITY: All fields auto-escaped by Jinja2 autoescape #}
+                    <td class="truncate" title="{{ result.repository_url }}">{{ result.repository_url }}</td>
+                    <td>{{ "%.1f"|format(result.assessment.overall_score) }}</td>
+                    <td>
+                        <span class="badge {{ result.assessment.certification_level.lower().replace(' ', '-') }}">
+                            {{ result.assessment.certification_level }}
+                        </span>
+                    </td>
+                    <td>{{ result.assessment.repository.primary_language }}</td>
+                    <td>{{ "%.1f"|format(result.duration_seconds) }}s</td>
+                    <td>
+                        {% set base_name = result.assessment.repository.name ~ '-' ~ result.assessment.timestamp.strftime('%Y%m%d-%H%M%S') %}
+                        <a href="{{ base_name }}.html">HTML</a> |
+                        <a href="{{ base_name }}.json">JSON</a> |
+                        <a href="{{ base_name }}.md">MD</a>
+                    </td>
+                </tr>
+                {% endif %}
+            {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <p class="no-data">No repository results available.</p>
+        {% endif %}
+
+        {% set failed_results = batch_assessment.results | selectattr('error', 'defined') | selectattr('error', 'ne', none) | list %}
+        {% if failed_results %}
+        <h2>❌ Failed Assessments</h2>
+        <table class="error-table">
+            <thead>
+                <tr>
+                    <th>Repository</th>
+                    <th>Error Type</th>
+                    <th>Error Message</th>
+                    <th>Duration</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for result in failed_results %}
+                <tr>
+                    {# SECURITY: All fields auto-escaped by Jinja2 autoescape #}
+                    <td class="truncate" title="{{ result.repository_url }}">{{ result.repository_url }}</td>
+                    <td>{{ result.error_type }}</td>
+                    <td class="truncate" title="{{ result.error }}">
+                        {{ result.error[:100] }}{% if result.error|length > 100 %}...{% endif %}
+                    </td>
+                    <td>{{ "%.1f"|format(result.duration_seconds) }}s</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
+
+        <hr style="margin: 3rem 0; border: none; border-top: 1px solid #ddd;">
+        <p style="text-align: center; color: var(--color-text-light); font-size: 0.875rem;">
+            Generated by <strong>AgentReady {{ batch_assessment.agentready_version }}</strong>
+            • Batch ID: {{ batch_assessment.batch_id }}
+        </p>
+    </div>
+</body>
+</html>

--- a/tests/integration/test_multi_reports.py
+++ b/tests/integration/test_multi_reports.py
@@ -1,0 +1,364 @@
+"""Integration tests for comprehensive multi-repository reporting."""
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from src.agentready.models.assessment import Assessment
+from src.agentready.models.batch_assessment import (
+    BatchAssessment,
+    BatchSummary,
+    RepositoryResult,
+)
+from src.agentready.models.repository import Repository
+from src.agentready.reporters.aggregated_json import AggregatedJSONReporter
+from src.agentready.reporters.csv_reporter import CSVReporter
+from src.agentready.reporters.html import HTMLReporter
+from src.agentready.reporters.json_reporter import JSONReporter
+from src.agentready.reporters.markdown import MarkdownReporter
+from src.agentready.reporters.multi_html import MultiRepoHTMLReporter
+
+
+@pytest.fixture
+def reports_dir(tmp_path):
+    """Create temporary reports directory."""
+    reports = tmp_path / "reports-20250122-143022"
+    reports.mkdir(parents=True)
+    return reports
+
+
+@pytest.fixture
+def template_dir():
+    """Get template directory path."""
+    return Path(__file__).parent.parent.parent / "src" / "agentready" / "templates"
+
+
+@pytest.fixture
+def mock_batch_assessment():
+    """Create a comprehensive mock batch assessment."""
+    # Create first repository and assessment
+    repo1 = Repository(
+        path=Path("/test/repo1"),
+        name="repo1",
+        branch="main",
+        commit_hash="abc123",
+        primary_language="Python",
+        languages={"Python": 50, "JavaScript": 10},
+        total_files=100,
+        total_lines=5000,
+    )
+    assessment1 = Assessment(
+        repository=repo1,
+        timestamp=datetime(2025, 1, 22, 14, 30, 22),
+        overall_score=85.5,
+        certification_level="Gold",
+        attributes_assessed=20,
+        attributes_not_assessed=5,
+        attributes_total=25,
+        findings=[],
+        duration_seconds=42.5,
+    )
+    result1 = RepositoryResult(
+        repository_url="https://github.com/user/repo1",
+        assessment=assessment1,
+        duration_seconds=42.5,
+        cached=False,
+    )
+
+    # Create second repository and assessment
+    repo2 = Repository(
+        path=Path("/test/repo2"),
+        name="repo2",
+        branch="develop",
+        commit_hash="def456",
+        primary_language="JavaScript",
+        languages={"JavaScript": 80, "TypeScript": 20},
+        total_files=150,
+        total_lines=7500,
+    )
+    assessment2 = Assessment(
+        repository=repo2,
+        timestamp=datetime(2025, 1, 22, 14, 35, 30),
+        overall_score=72.0,
+        certification_level="Silver",
+        attributes_assessed=20,
+        attributes_not_assessed=5,
+        attributes_total=25,
+        findings=[],
+        duration_seconds=38.0,
+    )
+    result2 = RepositoryResult(
+        repository_url="https://github.com/user/repo2",
+        assessment=assessment2,
+        duration_seconds=38.0,
+        cached=True,
+    )
+
+    # Create failed result
+    result3 = RepositoryResult(
+        repository_url="https://github.com/user/repo3",
+        assessment=None,
+        error="Clone timeout after 60 seconds",
+        error_type="timeout",
+        duration_seconds=120.0,
+        cached=False,
+    )
+
+    # Create summary
+    summary = BatchSummary(
+        total_repositories=3,
+        successful_assessments=2,
+        failed_assessments=1,
+        average_score=78.75,
+        score_distribution={"Gold": 1, "Silver": 1},
+        language_breakdown={"Python": 1, "JavaScript": 2},
+        top_failing_attributes=[
+            {"attribute_id": "1.1", "failure_count": 2},
+            {"attribute_id": "2.3", "failure_count": 1},
+        ],
+    )
+
+    return BatchAssessment(
+        batch_id="test-batch-20250122",
+        timestamp=datetime(2025, 1, 22, 14, 30, 0),
+        results=[result1, result2, result3],
+        summary=summary,
+        total_duration_seconds=200.5,
+        agentready_version="1.0.0",
+        command="assess-batch --repos-file repos.txt",
+    )
+
+
+class TestMultiReportGeneration:
+    """Integration tests for complete multi-repository reporting."""
+
+    def test_generate_all_reports(
+        self, reports_dir, template_dir, mock_batch_assessment
+    ):
+        """Test generating all report formats in dated folder."""
+        # 1. Generate CSV/TSV
+        csv_reporter = CSVReporter()
+        csv_path = csv_reporter.generate(
+            mock_batch_assessment, reports_dir / "summary.csv"
+        )
+        tsv_path = csv_reporter.generate(
+            mock_batch_assessment, reports_dir / "summary.tsv", delimiter="\t"
+        )
+
+        # 2. Generate aggregated JSON
+        json_reporter = AggregatedJSONReporter()
+        agg_json_path = json_reporter.generate(
+            mock_batch_assessment, reports_dir / "all-assessments.json"
+        )
+
+        # 3. Generate individual reports for successful assessments
+        html_reporter = HTMLReporter()
+        md_reporter = MarkdownReporter()
+        individual_json = JSONReporter()
+
+        individual_reports = []
+        for result in mock_batch_assessment.results:
+            if result.is_success():
+                assessment = result.assessment
+                base_name = (
+                    f"{assessment.repository.name}-"
+                    f"{assessment.timestamp.strftime('%Y%m%d-%H%M%S')}"
+                )
+
+                html_reporter.generate(assessment, reports_dir / f"{base_name}.html")
+                md_reporter.generate(assessment, reports_dir / f"{base_name}.md")
+                individual_json.generate(assessment, reports_dir / f"{base_name}.json")
+
+                individual_reports.append(base_name)
+
+        # 4. Generate multi-repo summary HTML
+        multi_html = MultiRepoHTMLReporter(template_dir)
+        index_path = multi_html.generate(
+            mock_batch_assessment, reports_dir / "index.html"
+        )
+
+        # Verify all files exist
+        assert csv_path.exists()
+        assert tsv_path.exists()
+        assert agg_json_path.exists()
+        assert index_path.exists()
+
+        # Verify individual reports
+        for base_name in individual_reports:
+            assert (reports_dir / f"{base_name}.html").exists()
+            assert (reports_dir / f"{base_name}.json").exists()
+            assert (reports_dir / f"{base_name}.md").exists()
+
+        # Verify expected number of files
+        # Expected: summary.csv, summary.tsv, all-assessments.json, index.html
+        #           + 3 files per successful assessment (2 successful)
+        #           = 4 + (3 * 2) = 10 files
+        all_files = list(reports_dir.iterdir())
+        assert len(all_files) == 10
+
+    def test_index_html_links_to_individual_reports(
+        self, reports_dir, template_dir, mock_batch_assessment
+    ):
+        """Test that index.html contains links to individual reports."""
+        # Generate individual reports first
+        html_reporter = HTMLReporter()
+        individual_json = JSONReporter()
+        md_reporter = MarkdownReporter()
+
+        for result in mock_batch_assessment.results:
+            if result.is_success():
+                assessment = result.assessment
+                base_name = (
+                    f"{assessment.repository.name}-"
+                    f"{assessment.timestamp.strftime('%Y%m%d-%H%M%S')}"
+                )
+
+                html_reporter.generate(assessment, reports_dir / f"{base_name}.html")
+                individual_json.generate(assessment, reports_dir / f"{base_name}.json")
+                md_reporter.generate(assessment, reports_dir / f"{base_name}.md")
+
+        # Generate index
+        multi_html = MultiRepoHTMLReporter(template_dir)
+        multi_html.generate(mock_batch_assessment, reports_dir / "index.html")
+
+        # Read index.html and verify links
+        index_content = (reports_dir / "index.html").read_text()
+
+        assert "repo1-20250122-143022.html" in index_content
+        assert "repo1-20250122-143022.json" in index_content
+        assert "repo2-20250122-143530.html" in index_content
+        assert "repo2-20250122-143530.json" in index_content
+
+    def test_csv_contains_all_results(self, reports_dir, mock_batch_assessment):
+        """Test that CSV contains all successful and failed results."""
+        csv_reporter = CSVReporter()
+        csv_reporter.generate(mock_batch_assessment, reports_dir / "summary.csv")
+
+        # Read CSV
+        import csv
+
+        with open(reports_dir / "summary.csv", "r", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        # Should have 3 rows (2 successful + 1 failed)
+        assert len(rows) == 3
+
+        # Verify successful results
+        success_rows = [r for r in rows if r["status"] == "success"]
+        assert len(success_rows) == 2
+        assert success_rows[0]["repo_name"] == "repo1"
+        assert success_rows[1]["repo_name"] == "repo2"
+
+        # Verify failed result
+        failed_rows = [r for r in rows if r["status"] == "failed"]
+        assert len(failed_rows) == 1
+        assert failed_rows[0]["error_type"] == "timeout"
+
+    def test_aggregated_json_structure(self, reports_dir, mock_batch_assessment):
+        """Test that aggregated JSON has correct structure."""
+        import json
+
+        json_reporter = AggregatedJSONReporter()
+        json_reporter.generate(
+            mock_batch_assessment, reports_dir / "all-assessments.json"
+        )
+
+        # Read JSON
+        with open(reports_dir / "all-assessments.json", "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        # Verify top-level structure
+        assert "batch_id" in data
+        assert "timestamp" in data
+        assert "results" in data
+        assert "summary" in data
+        assert "total_duration_seconds" in data
+        assert "agentready_version" in data
+
+        # Verify results
+        assert len(data["results"]) == 3
+        assert data["summary"]["total_repositories"] == 3
+        assert data["summary"]["successful_assessments"] == 2
+        assert data["summary"]["failed_assessments"] == 1
+
+    def test_reports_folder_structure_matches_specification(
+        self, tmp_path, template_dir, mock_batch_assessment
+    ):
+        """Test that reports folder structure matches Phase 2 specification."""
+        # Create dated reports folder
+        timestamp = "20250122-143022"
+        reports_dir = tmp_path / f"reports-{timestamp}"
+        reports_dir.mkdir(parents=True)
+
+        # Generate all reports
+        csv_reporter = CSVReporter()
+        csv_reporter.generate(mock_batch_assessment, reports_dir / "summary.csv")
+        csv_reporter.generate(
+            mock_batch_assessment, reports_dir / "summary.tsv", delimiter="\t"
+        )
+
+        json_reporter = AggregatedJSONReporter()
+        json_reporter.generate(
+            mock_batch_assessment, reports_dir / "all-assessments.json"
+        )
+
+        multi_html = MultiRepoHTMLReporter(template_dir)
+        multi_html.generate(mock_batch_assessment, reports_dir / "index.html")
+
+        # Generate individual reports
+        html_reporter = HTMLReporter()
+        md_reporter = MarkdownReporter()
+        individual_json = JSONReporter()
+
+        for result in mock_batch_assessment.results:
+            if result.is_success():
+                assessment = result.assessment
+                base_name = (
+                    f"{assessment.repository.name}-"
+                    f"{assessment.timestamp.strftime('%Y%m%d-%H%M%S')}"
+                )
+                html_reporter.generate(assessment, reports_dir / f"{base_name}.html")
+                md_reporter.generate(assessment, reports_dir / f"{base_name}.md")
+                individual_json.generate(assessment, reports_dir / f"{base_name}.json")
+
+        # Verify structure
+        assert (reports_dir / "index.html").exists()
+        assert (reports_dir / "summary.csv").exists()
+        assert (reports_dir / "summary.tsv").exists()
+        assert (reports_dir / "all-assessments.json").exists()
+        assert (reports_dir / "repo1-20250122-143022.html").exists()
+        assert (reports_dir / "repo1-20250122-143022.json").exists()
+        assert (reports_dir / "repo1-20250122-143022.md").exists()
+        assert (reports_dir / "repo2-20250122-143530.html").exists()
+        assert (reports_dir / "repo2-20250122-143530.json").exists()
+        assert (reports_dir / "repo2-20250122-143530.md").exists()
+
+    def test_security_controls_applied_across_all_reports(
+        self, reports_dir, template_dir, mock_batch_assessment
+    ):
+        """Test that security controls are applied across all report types."""
+        # Inject XSS/CSV injection payloads
+        mock_batch_assessment.results[0].assessment.repository.name = (
+            "=cmd|'/c calc'!A1"
+        )
+        mock_batch_assessment.results[1].repository_url = (
+            "javascript:alert('XSS')//https://fake.com"
+        )
+
+        # Generate all reports
+        csv_reporter = CSVReporter()
+        csv_reporter.generate(mock_batch_assessment, reports_dir / "summary.csv")
+
+        multi_html = MultiRepoHTMLReporter(template_dir)
+        multi_html.generate(mock_batch_assessment, reports_dir / "index.html")
+
+        # Verify CSV escaping
+        csv_content = (reports_dir / "summary.csv").read_text()
+        assert "'=" in csv_content or "\"'=" in csv_content
+
+        # Verify HTML escaping
+        html_content = (reports_dir / "index.html").read_text()
+        assert 'href="javascript:' not in html_content
+        assert "<script>" not in html_content

--- a/tests/security/__init__.py
+++ b/tests/security/__init__.py
@@ -1,0 +1,1 @@
+"""Security tests for AgentReady."""

--- a/tests/security/test_xss_prevention.py
+++ b/tests/security/test_xss_prevention.py
@@ -1,0 +1,337 @@
+"""Security tests for XSS and CSV injection prevention in multi-repo reports.
+
+CRITICAL: These tests verify security controls defined in the Phase 2 specification.
+All tests must pass before considering Phase 2 complete.
+"""
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from src.agentready.models.assessment import Assessment
+from src.agentready.models.batch_assessment import (
+    BatchAssessment,
+    BatchSummary,
+    RepositoryResult,
+)
+from src.agentready.models.repository import Repository
+from src.agentready.reporters.csv_reporter import CSVReporter
+from src.agentready.reporters.multi_html import MultiRepoHTMLReporter
+
+
+@pytest.fixture
+def template_dir():
+    """Get template directory path."""
+    return Path(__file__).parent.parent.parent / "src" / "agentready" / "templates"
+
+
+def create_test_batch_with_payload(payload: str, inject_location: str):
+    """Helper to create batch assessment with XSS/injection payload.
+
+    Args:
+        payload: Malicious payload to inject
+        inject_location: Where to inject ('repo_name', 'repo_url', 'error_message')
+    """
+    repo = Repository(
+        path=Path("/test"),
+        name="test-repo" if inject_location != "repo_name" else payload,
+        branch="main",
+        commit_hash="abc123",
+        primary_language="Python",
+        languages={"Python": 1},
+        total_files=1,
+        total_lines=1,
+    )
+
+    assessment = Assessment(
+        repository=repo,
+        timestamp=datetime.now(),
+        overall_score=50.0,
+        certification_level="Bronze",
+        attributes_assessed=1,
+        attributes_not_assessed=0,
+        attributes_total=1,
+        findings=[],
+        duration_seconds=1.0,
+    )
+
+    repo_url = (
+        "https://github.com/test/repo"
+        if inject_location != "repo_url"
+        else payload
+    )
+    error = payload if inject_location == "error_message" else None
+
+    if error:
+        result = RepositoryResult(
+            repository_url=repo_url,
+            assessment=None,
+            error=error,
+            error_type="test_error",
+            duration_seconds=1.0,
+        )
+        summary = BatchSummary(
+            total_repositories=1,
+            successful_assessments=0,
+            failed_assessments=1,
+            average_score=0.0,
+        )
+    else:
+        result = RepositoryResult(
+            repository_url=repo_url, assessment=assessment, duration_seconds=1.0
+        )
+        summary = BatchSummary(
+            total_repositories=1,
+            successful_assessments=1,
+            failed_assessments=0,
+            average_score=50.0,
+        )
+
+    return BatchAssessment(
+        batch_id="test",
+        timestamp=datetime.now(),
+        results=[result],
+        summary=summary,
+        total_duration_seconds=1.0,
+    )
+
+
+class TestXSSPrevention:
+    """Test suite for XSS prevention in HTML reports."""
+
+    @pytest.mark.parametrize(
+        "xss_payload",
+        [
+            "<script>alert('XSS')</script>",
+            "<img src=x onerror=alert(1)>",
+            "<svg onload=alert('XSS')>",
+            "javascript:alert('XSS')",
+            "<iframe src=javascript:alert('XSS')>",
+            "<body onload=alert('XSS')>",
+            "<input onfocus=alert('XSS') autofocus>",
+            "<marquee onstart=alert('XSS')>",
+            "'-alert('XSS')-'",
+            '"><script>alert(String.fromCharCode(88,83,83))</script>',
+        ],
+    )
+    def test_html_xss_prevention_in_repo_name(
+        self, template_dir, tmp_path, xss_payload
+    ):
+        """Test that XSS payloads in repository names are escaped."""
+        batch = create_test_batch_with_payload(xss_payload, "repo_name")
+
+        reporter = MultiRepoHTMLReporter(template_dir)
+        output_path = tmp_path / "test.html"
+        reporter.generate(batch, output_path)
+
+        html_content = output_path.read_text()
+
+        # Verify script tags are escaped
+        assert "<script>" not in html_content
+        assert "onerror=" not in html_content or "&quot;onerror=" in html_content
+        assert "onload=" not in html_content or "&quot;onload=" in html_content
+        assert "onfocus=" not in html_content or "&quot;onfocus=" in html_content
+        assert "onstart=" not in html_content or "&quot;onstart=" in html_content
+
+        # Verify alternative escape patterns
+        if "<" in xss_payload:
+            assert "&lt;" in html_content or "<script>" not in html_content
+
+    @pytest.mark.parametrize(
+        "malicious_url",
+        [
+            "javascript:alert('XSS')",
+            "data:text/html,<script>alert('XSS')</script>",
+            "vbscript:msgbox('XSS')",
+            "file:///etc/passwd",
+            "about:blank",
+        ],
+    )
+    def test_html_url_sanitization(self, template_dir, tmp_path, malicious_url):
+        """Test that malicious URLs are blocked."""
+        batch = create_test_batch_with_payload(malicious_url, "repo_url")
+
+        reporter = MultiRepoHTMLReporter(template_dir)
+        output_path = tmp_path / "test.html"
+        reporter.generate(batch, output_path)
+
+        html_content = output_path.read_text()
+
+        # Verify malicious schemes are not present as clickable links
+        assert 'href="javascript:' not in html_content
+        assert 'href="data:' not in html_content
+        assert 'href="vbscript:' not in html_content
+        assert 'href="file:' not in html_content
+
+    def test_html_xss_prevention_in_error_message(self, template_dir, tmp_path):
+        """Test that XSS in error messages is prevented."""
+        xss_payload = "<script>alert('XSS from error')</script>"
+        batch = create_test_batch_with_payload(xss_payload, "error_message")
+
+        reporter = MultiRepoHTMLReporter(template_dir)
+        output_path = tmp_path / "test.html"
+        reporter.generate(batch, output_path)
+
+        html_content = output_path.read_text()
+
+        # Verify script tag is escaped
+        assert "<script>" not in html_content
+        assert "&lt;script&gt;" in html_content or "script" not in html_content.lower()
+
+    def test_html_autoescape_enabled(self, template_dir):
+        """Verify that Jinja2 autoescape is enabled (CRITICAL SECURITY CHECK)."""
+        reporter = MultiRepoHTMLReporter(template_dir)
+        # Autoescape should be True or a callable selector
+        assert reporter.env.autoescape is True or callable(reporter.env.autoescape)
+
+    def test_html_csp_header_present(self, template_dir, tmp_path):
+        """Verify that Content Security Policy header is present (CRITICAL)."""
+        batch = create_test_batch_with_payload("test", "repo_name")
+
+        reporter = MultiRepoHTMLReporter(template_dir)
+        output_path = tmp_path / "test.html"
+        reporter.generate(batch, output_path)
+
+        html_content = output_path.read_text()
+
+        # Verify CSP header is present and restrictive
+        assert "Content-Security-Policy" in html_content
+        assert "script-src 'none'" in html_content or "script-src" in html_content
+
+
+class TestCSVInjectionPrevention:
+    """Test suite for CSV formula injection prevention."""
+
+    @pytest.mark.parametrize(
+        "injection_payload",
+        [
+            "=1+1",
+            "=cmd|'/c calc'!A1",
+            "+1+1",
+            "+cmd",
+            "-1+1",
+            "-cmd",
+            "@SUM(A1:A10)",
+            "\tcmd",
+            "\rcmd",
+            "=HYPERLINK('http://evil.com', 'click')",
+            "=1+1+cmd|' /C calc'!A1",
+            "@cmd|'/c calc'!A1",
+        ],
+    )
+    def test_csv_formula_injection_prevention_in_repo_name(
+        self, tmp_path, injection_payload
+    ):
+        """Test that CSV formula injection payloads are escaped."""
+        batch = create_test_batch_with_payload(injection_payload, "repo_name")
+
+        reporter = CSVReporter()
+        output_path = tmp_path / "test.csv"
+        reporter.generate(batch, output_path)
+
+        csv_content = output_path.read_text()
+
+        # Verify formula characters are escaped with leading single quote
+        first_char = injection_payload[0]
+        if first_char in CSVReporter.FORMULA_CHARS:
+            # Should be prefixed with single quote
+            assert f"'{first_char}" in csv_content or f'"{first_char}' in csv_content
+
+    def test_csv_formula_injection_prevention_in_error_message(self, tmp_path):
+        """Test that CSV formula injection in error messages is prevented."""
+        injection_payload = "=HYPERLINK('http://evil.com')"
+        batch = create_test_batch_with_payload(injection_payload, "error_message")
+
+        reporter = CSVReporter()
+        output_path = tmp_path / "test.csv"
+        reporter.generate(batch, output_path)
+
+        csv_content = output_path.read_text()
+
+        # Verify formula is escaped
+        assert "'=" in csv_content or "\"'=" in csv_content
+
+    def test_csv_sanitize_field_static_method(self):
+        """Test the sanitize_csv_field method directly."""
+        reporter = CSVReporter()
+
+        # Test formula characters
+        assert reporter.sanitize_csv_field("=1+1") == "'=1+1"
+        assert reporter.sanitize_csv_field("+cmd") == "'+cmd"
+        assert reporter.sanitize_csv_field("-cmd") == "'-cmd"
+        assert reporter.sanitize_csv_field("@SUM") == "'@SUM"
+        assert reporter.sanitize_csv_field("\tcmd") == "'\tcmd"
+        assert reporter.sanitize_csv_field("\rcmd") == "'\rcmd"
+
+        # Test normal text (should not be modified)
+        assert reporter.sanitize_csv_field("normal text") == "normal text"
+        assert reporter.sanitize_csv_field("test-repo") == "test-repo"
+
+        # Test None
+        assert reporter.sanitize_csv_field(None) == ""
+
+    def test_tsv_formula_injection_prevention(self, tmp_path):
+        """Test that TSV (tab-delimited) also prevents formula injection."""
+        injection_payload = "=cmd|'/c calc'!A1"
+        batch = create_test_batch_with_payload(injection_payload, "repo_name")
+
+        reporter = CSVReporter()
+        output_path = tmp_path / "test.tsv"
+        reporter.generate(batch, output_path, delimiter="\t")
+
+        tsv_content = output_path.read_text()
+
+        # Verify formula is escaped
+        assert "'=" in tsv_content or "\"'=" in tsv_content
+
+
+class TestSecurityChecklist:
+    """Verify all security controls from Phase 2 specification."""
+
+    def test_jinja2_autoescape_enabled(self, template_dir):
+        """✓ Jinja2 autoescape enabled in MultiRepoHTMLReporter."""
+        reporter = MultiRepoHTMLReporter(template_dir)
+        assert reporter.env.autoescape is True or callable(reporter.env.autoescape)
+
+    def test_html_escaping_verified(self, template_dir, tmp_path):
+        """✓ HTML escaping verified (test with <script> tags)."""
+        batch = create_test_batch_with_payload("<script>alert(1)</script>", "repo_name")
+        reporter = MultiRepoHTMLReporter(template_dir)
+        output_path = tmp_path / "test.html"
+        reporter.generate(batch, output_path)
+
+        html_content = output_path.read_text()
+        assert "<script>" not in html_content
+
+    def test_url_sanitization_verified(self, template_dir, tmp_path):
+        """✓ URL sanitization verified (test with javascript: URLs)."""
+        batch = create_test_batch_with_payload("javascript:alert(1)", "repo_url")
+        reporter = MultiRepoHTMLReporter(template_dir)
+        output_path = tmp_path / "test.html"
+        reporter.generate(batch, output_path)
+
+        html_content = output_path.read_text()
+        assert 'href="javascript:' not in html_content
+
+    def test_csp_header_present(self, template_dir, tmp_path):
+        """✓ CSP header present in HTML reports."""
+        batch = create_test_batch_with_payload("test", "repo_name")
+        reporter = MultiRepoHTMLReporter(template_dir)
+        output_path = tmp_path / "test.html"
+        reporter.generate(batch, output_path)
+
+        html_content = output_path.read_text()
+        assert "Content-Security-Policy" in html_content
+
+    def test_csv_formula_escaping_verified(self, tmp_path):
+        """✓ CSV formula character escaping verified."""
+        # Test all formula characters
+        for char in ["=", "+", "-", "@"]:
+            batch = create_test_batch_with_payload(f"{char}cmd", "repo_name")
+            reporter = CSVReporter()
+            output_path = tmp_path / f"test_{char}.csv"
+            reporter.generate(batch, output_path)
+
+            csv_content = output_path.read_text()
+            assert f"'{char}" in csv_content or f'"{char}' in csv_content

--- a/tests/unit/test_csv_reporter.py
+++ b/tests/unit/test_csv_reporter.py
@@ -1,0 +1,336 @@
+"""Unit tests for CSV reporter with security controls."""
+
+import csv
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from src.agentready.models.assessment import Assessment
+from src.agentready.models.batch_assessment import (
+    BatchAssessment,
+    BatchSummary,
+    RepositoryResult,
+)
+from src.agentready.models.repository import Repository
+from src.agentready.reporters.csv_reporter import CSVReporter
+
+
+@pytest.fixture
+def temp_csv_file(tmp_path):
+    """Create temporary CSV file for testing."""
+    return tmp_path / "test_report.csv"
+
+
+@pytest.fixture
+def temp_tsv_file(tmp_path):
+    """Create temporary TSV file for testing."""
+    return tmp_path / "test_report.tsv"
+
+
+@pytest.fixture
+def mock_repository():
+    """Create a mock repository for testing."""
+    return Repository(
+        path=Path("/test/repo"),
+        name="test-repo",
+        branch="main",
+        commit_hash="abc123def456",
+        primary_language="Python",
+        languages={"Python": 10},
+        total_files=100,
+        total_lines=5000,
+    )
+
+
+@pytest.fixture
+def mock_assessment(mock_repository):
+    """Create a mock assessment for testing."""
+    return Assessment(
+        repository=mock_repository,
+        timestamp=datetime(2025, 1, 22, 14, 30, 22),
+        overall_score=85.5,
+        certification_level="Gold",
+        attributes_assessed=20,
+        attributes_not_assessed=5,
+        attributes_total=25,
+        findings=[],
+        duration_seconds=42.5,
+    )
+
+
+@pytest.fixture
+def mock_batch_assessment(mock_assessment):
+    """Create a mock batch assessment for testing."""
+    # Create successful result
+    result1 = RepositoryResult(
+        repository_url="https://github.com/user/repo1",
+        assessment=mock_assessment,
+        duration_seconds=42.5,
+        cached=False,
+    )
+
+    # Create another successful result
+    repo2 = Repository(
+        path=Path("/test/repo2"),
+        name="test-repo-2",
+        branch="main",
+        commit_hash="def789abc123",
+        primary_language="JavaScript",
+        languages={"JavaScript": 15},
+        total_files=75,
+        total_lines=3000,
+    )
+    assessment2 = Assessment(
+        repository=repo2,
+        timestamp=datetime(2025, 1, 22, 14, 35, 30),
+        overall_score=72.0,
+        certification_level="Silver",
+        attributes_assessed=20,
+        attributes_not_assessed=5,
+        attributes_total=25,
+        findings=[],
+        duration_seconds=38.0,
+    )
+    result2 = RepositoryResult(
+        repository_url="https://github.com/user/repo2",
+        assessment=assessment2,
+        duration_seconds=38.0,
+        cached=True,
+    )
+
+    # Create failed result
+    result3 = RepositoryResult(
+        repository_url="https://github.com/user/repo3",
+        assessment=None,
+        error="Clone timeout",
+        error_type="timeout",
+        duration_seconds=120.0,
+        cached=False,
+    )
+
+    summary = BatchSummary(
+        total_repositories=3,
+        successful_assessments=2,
+        failed_assessments=1,
+        average_score=78.75,
+        score_distribution={"Gold": 1, "Silver": 1},
+        language_breakdown={"Python": 1, "JavaScript": 1},
+        top_failing_attributes=[],
+    )
+
+    return BatchAssessment(
+        batch_id="test-batch-123",
+        timestamp=datetime(2025, 1, 22, 14, 30, 0),
+        results=[result1, result2, result3],
+        summary=summary,
+        total_duration_seconds=200.5,
+        agentready_version="1.0.0",
+        command="assess-batch",
+    )
+
+
+class TestCSVReporter:
+    """Test suite for CSVReporter."""
+
+    def test_sanitize_csv_field_normal_text(self):
+        """Test that normal text is not modified."""
+        reporter = CSVReporter()
+        assert reporter.sanitize_csv_field("normal text") == "normal text"
+        assert reporter.sanitize_csv_field("test-repo") == "test-repo"
+        assert reporter.sanitize_csv_field("123") == "123"
+
+    def test_sanitize_csv_field_none(self):
+        """Test that None becomes empty string."""
+        reporter = CSVReporter()
+        assert reporter.sanitize_csv_field(None) == ""
+
+    def test_sanitize_csv_field_formula_injection_equals(self):
+        """Test that equals sign is escaped (CSV injection prevention)."""
+        reporter = CSVReporter()
+        assert reporter.sanitize_csv_field("=1+1") == "'=1+1"
+        assert reporter.sanitize_csv_field("=cmd|'/c calc'!A1") == "'=cmd|'/c calc'!A1"
+
+    def test_sanitize_csv_field_formula_injection_plus(self):
+        """Test that plus sign is escaped (CSV injection prevention)."""
+        reporter = CSVReporter()
+        assert reporter.sanitize_csv_field("+1+1") == "'+1+1"
+        assert reporter.sanitize_csv_field("+cmd") == "'+cmd"
+
+    def test_sanitize_csv_field_formula_injection_minus(self):
+        """Test that minus sign is escaped (CSV injection prevention)."""
+        reporter = CSVReporter()
+        assert reporter.sanitize_csv_field("-1+1") == "'-1+1"
+        assert reporter.sanitize_csv_field("-cmd") == "'-cmd"
+
+    def test_sanitize_csv_field_formula_injection_at(self):
+        """Test that at sign is escaped (CSV injection prevention)."""
+        reporter = CSVReporter()
+        assert reporter.sanitize_csv_field("@SUM(A1:A10)") == "'@SUM(A1:A10)"
+
+    def test_sanitize_csv_field_formula_injection_tab(self):
+        """Test that tab is escaped (CSV injection prevention)."""
+        reporter = CSVReporter()
+        assert reporter.sanitize_csv_field("\tcmd") == "'\tcmd"
+
+    def test_sanitize_csv_field_formula_injection_carriage_return(self):
+        """Test that carriage return is escaped (CSV injection prevention)."""
+        reporter = CSVReporter()
+        assert reporter.sanitize_csv_field("\rcmd") == "'\rcmd"
+
+    def test_generate_csv_success(self, mock_batch_assessment, temp_csv_file):
+        """Test CSV generation with successful assessments."""
+        reporter = CSVReporter()
+        result_path = reporter.generate(mock_batch_assessment, temp_csv_file)
+
+        assert result_path == temp_csv_file
+        assert temp_csv_file.exists()
+
+        # Read and verify CSV content
+        with open(temp_csv_file, "r", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        assert len(rows) == 3  # 2 successful + 1 failed
+
+        # Verify successful row
+        assert rows[0]["repo_url"] == "https://github.com/user/repo1"
+        assert rows[0]["repo_name"] == "test-repo"
+        assert rows[0]["overall_score"] == "85.5"
+        assert rows[0]["certification_level"] == "Gold"
+        assert rows[0]["primary_language"] == "Python"
+        assert rows[0]["status"] == "success"
+        assert rows[0]["cached"] == "False"
+
+        # Verify second successful row
+        assert rows[1]["repo_url"] == "https://github.com/user/repo2"
+        assert rows[1]["cached"] == "True"
+
+        # Verify failed row
+        assert rows[2]["repo_url"] == "https://github.com/user/repo3"
+        assert rows[2]["status"] == "failed"
+        assert rows[2]["error_type"] == "timeout"
+        assert rows[2]["error_message"] == "Clone timeout"
+
+    def test_generate_tsv_success(self, mock_batch_assessment, temp_tsv_file):
+        """Test TSV generation (tab delimiter)."""
+        reporter = CSVReporter()
+        result_path = reporter.generate(
+            mock_batch_assessment, temp_tsv_file, delimiter="\t"
+        )
+
+        assert result_path == temp_tsv_file
+        assert temp_tsv_file.exists()
+
+        # Read and verify TSV content
+        with open(temp_tsv_file, "r", encoding="utf-8") as f:
+            reader = csv.DictReader(f, delimiter="\t")
+            rows = list(reader)
+
+        assert len(rows) == 3
+
+    def test_csv_formula_injection_in_repo_name(
+        self, mock_batch_assessment, temp_csv_file
+    ):
+        """Test that formula injection in repo name is prevented."""
+        # Modify repository name to contain formula
+        mock_batch_assessment.results[0].assessment.repository.name = "=cmd|'/c calc'!A1"
+
+        reporter = CSVReporter()
+        reporter.generate(mock_batch_assessment, temp_csv_file)
+
+        # Read CSV and verify escaping
+        with open(temp_csv_file, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # The formula should be escaped with a leading single quote
+        assert "'=cmd|'/c calc'!A1" in content or "\"'=cmd" in content
+
+    def test_csv_formula_injection_in_error_message(
+        self, mock_batch_assessment, temp_csv_file
+    ):
+        """Test that formula injection in error message is prevented."""
+        # Modify error message to contain formula
+        mock_batch_assessment.results[2].error = "=HYPERLINK('http://evil.com')"
+
+        reporter = CSVReporter()
+        reporter.generate(mock_batch_assessment, temp_csv_file)
+
+        # Read CSV and verify escaping
+        with open(temp_csv_file, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # The formula should be escaped
+        assert "'=" in content or "\"'=" in content
+
+    def test_csv_empty_batch(self, tmp_path):
+        """Test CSV generation with no results."""
+        # Create batch with no results (this should not happen in practice)
+        summary = BatchSummary(
+            total_repositories=0,
+            successful_assessments=0,
+            failed_assessments=0,
+            average_score=0.0,
+        )
+        batch = BatchAssessment(
+            batch_id="empty-batch",
+            timestamp=datetime.now(),
+            results=[],
+            summary=summary,
+            total_duration_seconds=0.0,
+        )
+
+        reporter = CSVReporter()
+        output_path = tmp_path / "empty.csv"
+
+        # Should not raise error, but will only have header
+        with pytest.raises(ValueError, match="Batch must have at least one result"):
+            reporter.generate(batch, output_path)
+
+    def test_csv_creates_parent_directory(self, tmp_path):
+        """Test that CSV reporter creates parent directories if needed."""
+        nested_path = tmp_path / "nested" / "dir" / "report.csv"
+
+        # Create a minimal batch assessment
+        repo = Repository(
+            path=Path("/test"),
+            name="test",
+            branch="main",
+            commit_hash="abc123",
+            primary_language="Python",
+            languages={},
+            total_files=1,
+            total_lines=1,
+        )
+        assessment = Assessment(
+            repository=repo,
+            timestamp=datetime.now(),
+            overall_score=50.0,
+            certification_level="Bronze",
+            attributes_assessed=1,
+            attributes_not_assessed=0,
+            attributes_total=1,
+            findings=[],
+            duration_seconds=1.0,
+        )
+        result = RepositoryResult(
+            repository_url="https://test.com", assessment=assessment
+        )
+        summary = BatchSummary(
+            total_repositories=1,
+            successful_assessments=1,
+            failed_assessments=0,
+            average_score=50.0,
+        )
+        batch = BatchAssessment(
+            batch_id="test",
+            timestamp=datetime.now(),
+            results=[result],
+            summary=summary,
+            total_duration_seconds=1.0,
+        )
+
+        reporter = CSVReporter()
+        reporter.generate(batch, nested_path)
+
+        assert nested_path.exists()

--- a/tests/unit/test_multi_html_reporter.py
+++ b/tests/unit/test_multi_html_reporter.py
@@ -1,0 +1,339 @@
+"""Unit tests for multi-repository HTML reporter with security controls."""
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from src.agentready.models.assessment import Assessment
+from src.agentready.models.batch_assessment import (
+    BatchAssessment,
+    BatchSummary,
+    RepositoryResult,
+)
+from src.agentready.models.repository import Repository
+from src.agentready.reporters.multi_html import MultiRepoHTMLReporter
+
+
+@pytest.fixture
+def template_dir():
+    """Get template directory path."""
+    return Path(__file__).parent.parent.parent / "src" / "agentready" / "templates"
+
+
+@pytest.fixture
+def temp_html_file(tmp_path):
+    """Create temporary HTML file for testing."""
+    return tmp_path / "index.html"
+
+
+@pytest.fixture
+def mock_repository():
+    """Create a mock repository for testing."""
+    return Repository(
+        path=Path("/test/repo"),
+        name="test-repo",
+        branch="main",
+        commit_hash="abc123def456",
+        primary_language="Python",
+        languages={"Python": 10},
+        total_files=100,
+        total_lines=5000,
+    )
+
+
+@pytest.fixture
+def mock_assessment(mock_repository):
+    """Create a mock assessment for testing."""
+    return Assessment(
+        repository=mock_repository,
+        timestamp=datetime(2025, 1, 22, 14, 30, 22),
+        overall_score=85.5,
+        certification_level="Gold",
+        attributes_assessed=20,
+        attributes_not_assessed=5,
+        attributes_total=25,
+        findings=[],
+        duration_seconds=42.5,
+    )
+
+
+@pytest.fixture
+def mock_batch_assessment(mock_assessment):
+    """Create a mock batch assessment for testing."""
+    result1 = RepositoryResult(
+        repository_url="https://github.com/user/repo1",
+        assessment=mock_assessment,
+        duration_seconds=42.5,
+        cached=False,
+    )
+
+    summary = BatchSummary(
+        total_repositories=1,
+        successful_assessments=1,
+        failed_assessments=0,
+        average_score=85.5,
+        score_distribution={"Gold": 1},
+        language_breakdown={"Python": 1},
+        top_failing_attributes=[{"attribute_id": "1.1", "failure_count": 5}],
+    )
+
+    return BatchAssessment(
+        batch_id="test-batch-123",
+        timestamp=datetime(2025, 1, 22, 14, 30, 0),
+        results=[result1],
+        summary=summary,
+        total_duration_seconds=42.5,
+        agentready_version="1.0.0",
+        command="assess-batch",
+    )
+
+
+class TestMultiRepoHTMLReporter:
+    """Test suite for MultiRepoHTMLReporter."""
+
+    def test_sanitize_url_valid_https(self):
+        """Test that valid HTTPS URLs are allowed and escaped."""
+        reporter = MultiRepoHTMLReporter(Path("/tmp"))
+        url = "https://github.com/user/repo"
+        result = reporter.sanitize_url(url)
+        assert "github.com" in result
+        assert result.startswith("https://")
+
+    def test_sanitize_url_valid_http(self):
+        """Test that valid HTTP URLs are allowed and escaped."""
+        reporter = MultiRepoHTMLReporter(Path("/tmp"))
+        url = "http://example.com/path"
+        result = reporter.sanitize_url(url)
+        assert "example.com" in result
+
+    def test_sanitize_url_javascript_scheme_blocked(self):
+        """Test that javascript: URLs are blocked (XSS prevention)."""
+        reporter = MultiRepoHTMLReporter(Path("/tmp"))
+        url = "javascript:alert('XSS')"
+        result = reporter.sanitize_url(url)
+        assert result == ""
+
+    def test_sanitize_url_data_scheme_blocked(self):
+        """Test that data: URLs are blocked (XSS prevention)."""
+        reporter = MultiRepoHTMLReporter(Path("/tmp"))
+        url = "data:text/html,<script>alert('XSS')</script>"
+        result = reporter.sanitize_url(url)
+        assert result == ""
+
+    def test_sanitize_url_file_scheme_blocked(self):
+        """Test that file: URLs are blocked (security)."""
+        reporter = MultiRepoHTMLReporter(Path("/tmp"))
+        url = "file:///etc/passwd"
+        result = reporter.sanitize_url(url)
+        assert result == ""
+
+    def test_sanitize_url_empty_string(self):
+        """Test that empty string returns empty string."""
+        reporter = MultiRepoHTMLReporter(Path("/tmp"))
+        assert reporter.sanitize_url("") == ""
+        assert reporter.sanitize_url(None) == ""
+
+    def test_sanitize_url_html_escape(self):
+        """Test that URLs with special HTML characters are escaped."""
+        reporter = MultiRepoHTMLReporter(Path("/tmp"))
+        url = "https://example.com/path?param=<script>"
+        result = reporter.sanitize_url(url)
+        # Should escape < and >
+        assert "&lt;" in result or "<" not in result
+
+    def test_generate_html_success(
+        self, template_dir, mock_batch_assessment, temp_html_file
+    ):
+        """Test HTML generation with successful batch assessment."""
+        reporter = MultiRepoHTMLReporter(template_dir)
+        result_path = reporter.generate(mock_batch_assessment, temp_html_file)
+
+        assert result_path == temp_html_file
+        assert temp_html_file.exists()
+
+        # Read HTML content
+        html_content = temp_html_file.read_text(encoding="utf-8")
+
+        # Verify basic structure
+        assert "<!DOCTYPE html>" in html_content
+        assert "<html" in html_content
+        assert "</html>" in html_content
+
+        # Verify CSP header
+        assert "Content-Security-Policy" in html_content
+        assert "script-src 'none'" in html_content
+
+        # Verify content
+        assert "Multi-Repository Assessment Report" in html_content
+        assert "test-batch-123" in html_content
+        assert "1.0.0" in html_content  # AgentReady version
+        assert "85.5" in html_content  # Score
+
+    def test_generate_html_xss_prevention_repo_name(
+        self, template_dir, mock_batch_assessment, temp_html_file
+    ):
+        """Test that XSS in repository name is prevented."""
+        # Inject XSS payload into repository name
+        mock_batch_assessment.results[
+            0
+        ].assessment.repository.name = "<script>alert('XSS')</script>"
+
+        reporter = MultiRepoHTMLReporter(template_dir)
+        reporter.generate(mock_batch_assessment, temp_html_file)
+
+        html_content = temp_html_file.read_text(encoding="utf-8")
+
+        # Verify script tag is escaped
+        assert "<script>" not in html_content
+        assert "&lt;script&gt;" in html_content or "script" not in html_content.lower()
+
+    def test_generate_html_xss_prevention_repo_url(
+        self, template_dir, mock_batch_assessment, temp_html_file
+    ):
+        """Test that XSS in repository URL is prevented."""
+        # Inject XSS payload into repository URL
+        mock_batch_assessment.results[0].repository_url = (
+            "javascript:alert('XSS')//https://fake.com"
+        )
+
+        reporter = MultiRepoHTMLReporter(template_dir)
+        reporter.generate(mock_batch_assessment, temp_html_file)
+
+        html_content = temp_html_file.read_text(encoding="utf-8")
+
+        # Verify javascript: is not present as a clickable link
+        # Note: The sanitize_url filter should have blocked it
+        assert 'href="javascript:' not in html_content
+
+    def test_generate_html_xss_prevention_error_message(
+        self, template_dir, mock_batch_assessment, temp_html_file
+    ):
+        """Test that XSS in error message is prevented."""
+        # Add failed result with XSS payload
+        failed_result = RepositoryResult(
+            repository_url="https://github.com/user/bad",
+            assessment=None,
+            error="<img src=x onerror=alert('XSS')>",
+            error_type="test_error",
+            duration_seconds=1.0,
+        )
+        mock_batch_assessment.results.append(failed_result)
+        mock_batch_assessment.summary.failed_assessments = 1
+
+        reporter = MultiRepoHTMLReporter(template_dir)
+        reporter.generate(mock_batch_assessment, temp_html_file)
+
+        html_content = temp_html_file.read_text(encoding="utf-8")
+
+        # Verify img tag is escaped
+        assert "<img" not in html_content or "&lt;img" in html_content
+        assert "onerror=" not in html_content
+
+    def test_generate_html_autoescape_enabled(self, template_dir):
+        """Test that Jinja2 autoescape is enabled."""
+        reporter = MultiRepoHTMLReporter(template_dir)
+        assert reporter.env.autoescape is True or callable(reporter.env.autoescape)
+
+    def test_generate_html_with_failed_assessments(
+        self, template_dir, mock_batch_assessment, temp_html_file
+    ):
+        """Test HTML generation includes failed assessments section."""
+        # Add failed result
+        failed_result = RepositoryResult(
+            repository_url="https://github.com/user/failed-repo",
+            assessment=None,
+            error="Clone timeout",
+            error_type="timeout",
+            duration_seconds=120.0,
+        )
+        mock_batch_assessment.results.append(failed_result)
+        mock_batch_assessment.summary.failed_assessments = 1
+        mock_batch_assessment.summary.total_repositories = 2
+
+        reporter = MultiRepoHTMLReporter(template_dir)
+        reporter.generate(mock_batch_assessment, temp_html_file)
+
+        html_content = temp_html_file.read_text(encoding="utf-8")
+
+        # Verify failed assessments section
+        assert "Failed Assessments" in html_content or "failed" in html_content.lower()
+        assert "timeout" in html_content
+        assert "Clone timeout" in html_content
+
+    def test_generate_html_certification_badges(
+        self, template_dir, mock_batch_assessment, temp_html_file
+    ):
+        """Test that certification badges are rendered correctly."""
+        reporter = MultiRepoHTMLReporter(template_dir)
+        reporter.generate(mock_batch_assessment, temp_html_file)
+
+        html_content = temp_html_file.read_text(encoding="utf-8")
+
+        # Verify Gold badge is present
+        assert "Gold" in html_content
+        assert "gold" in html_content.lower()  # CSS class
+
+    def test_generate_html_creates_parent_directory(self, template_dir, tmp_path):
+        """Test that HTML reporter creates parent directories if needed."""
+        nested_path = tmp_path / "nested" / "dir" / "index.html"
+
+        # Create minimal batch assessment
+        repo = Repository(
+            path=Path("/test"),
+            name="test",
+            branch="main",
+            commit_hash="abc123",
+            primary_language="Python",
+            languages={},
+            total_files=1,
+            total_lines=1,
+        )
+        assessment = Assessment(
+            repository=repo,
+            timestamp=datetime.now(),
+            overall_score=50.0,
+            certification_level="Bronze",
+            attributes_assessed=1,
+            attributes_not_assessed=0,
+            attributes_total=1,
+            findings=[],
+            duration_seconds=1.0,
+        )
+        result = RepositoryResult(
+            repository_url="https://test.com", assessment=assessment
+        )
+        summary = BatchSummary(
+            total_repositories=1,
+            successful_assessments=1,
+            failed_assessments=0,
+            average_score=50.0,
+        )
+        batch = BatchAssessment(
+            batch_id="test",
+            timestamp=datetime.now(),
+            results=[result],
+            summary=summary,
+            total_duration_seconds=1.0,
+        )
+
+        reporter = MultiRepoHTMLReporter(template_dir)
+        reporter.generate(batch, nested_path)
+
+        assert nested_path.exists()
+
+    def test_generate_html_responsive_design(
+        self, template_dir, mock_batch_assessment, temp_html_file
+    ):
+        """Test that HTML includes responsive design elements."""
+        reporter = MultiRepoHTMLReporter(template_dir)
+        reporter.generate(mock_batch_assessment, temp_html_file)
+
+        html_content = temp_html_file.read_text(encoding="utf-8")
+
+        # Check for viewport meta tag
+        assert "viewport" in html_content
+        assert "width=device-width" in html_content
+
+        # Check for media queries or responsive CSS
+        assert "@media" in html_content or "max-width" in html_content


### PR DESCRIPTION
Implements Phase 2 of the multi-repository assessment feature with comprehensive reporting in multiple formats.

## Changes

- Add CSVReporter with CSV formula injection prevention (CWE-1236)
- Add AggregatedJSONReporter for batch exports
- Add JSONReporter for individual exports
- Add MultiRepoHTMLReporter with XSS prevention
- Create multi_report.html.j2 template with CSP headers
- Enhance assess-batch CLI with dated folder reporting
- Add comprehensive test suite (unit, integration, security)

## Security Controls

- Jinja2 autoescape enabled (prevents XSS)
- URL scheme validation (blocks javascript:, data:, file:)
- Content Security Policy headers
- CSV formula character escaping

## Report Structure

```
reports-YYYYMMDD-HHMMSS/
├── index.html
├── summary.csv & summary.tsv
├── all-assessments.json
├── Individual reports per repo (HTML/JSON/MD)
└── failures.json
```

Closes #69

🤖 Generated with [Claude Code](https://claude.ai/code)