### PR TITLE
feat: Phase 3 - GitHub Organization Scanning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,76 @@ agentready migrate-report old-report.json --to 2.0.0
 
 ---
 
+## Batch Assessment & GitHub Integration
+
+**Feature**: Assess multiple repositories in a single operation, including scanning entire GitHub organizations.
+
+The `assess-batch` command enables bulk repository assessment with support for file-based lists, inline arguments, and direct GitHub organization scanning.
+
+### Basic Usage
+
+```bash
+# Assess repositories from a file
+agentready assess-batch --repos-file repos.txt
+
+# Assess specific repositories
+agentready assess-batch \
+  --repos https://github.com/user/repo1 \
+  --repos https://github.com/user/repo2
+
+# Combine multiple sources
+agentready assess-batch \
+  --repos-file my-repos.txt \
+  --repos https://github.com/user/extra-repo
+```
+
+### GitHub Organization Scanning
+
+Assess all repositories in a GitHub organization:
+
+```bash
+# Set GitHub token
+export GITHUB_TOKEN=ghp_your_token_here
+
+# Scan public repos only (default)
+agentready assess-batch --github-org anthropics
+
+# Include private repos
+agentready assess-batch --github-org myorg --include-private
+
+# Limit number of repos
+agentready assess-batch --github-org myorg --max-repos 50
+
+# Combine with other sources
+agentready assess-batch \
+  --github-org myorg \
+  --repos-file additional-repos.txt \
+  --verbose
+```
+
+**Token Setup**:
+1. Create personal access token: https://github.com/settings/tokens
+2. Required scopes: `repo:status`, `public_repo`
+3. For private repos: `repo` (full control)
+4. Set environment variable: `export GITHUB_TOKEN=ghp_...`
+
+**Security Features**:
+- Token stored in environment only (never in files)
+- Token redacted in all logs and errors
+- Public repos scanned by default (safe)
+- Private repos require explicit `--include-private` flag
+- Organization name validated to prevent injection attacks
+- Repository limit enforced (default: 100)
+- Rate limiting implemented (0.2s between API requests)
+
+**Output**:
+- Batch reports saved to `.agentready/batch/` by default
+- Individual repository assessments cached
+- Summary statistics across all repositories
+- Aggregate scoring and failure analysis
+
+---
+
 ## Continuous Learning Loop (LLM-Powered)
 
 **Feature**: Extract high-quality skills from assessments using Claude API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "lizard>=1.17.0",
     "anthropic>=0.74.0",
     "jsonschema>=4.17.0",
+    "requests>=2.31.0",
 ]
 
 [project.optional-dependencies]

--- a/src/agentready/cli/assess_batch.py
+++ b/src/agentready/cli/assess_batch.py
@@ -167,6 +167,21 @@ def _load_config(config_path: Path) -> Config:
     help="Repository URLs/paths (can be specified multiple times)",
 )
 @click.option(
+    "--github-org",
+    help="GitHub organization name to scan",
+)
+@click.option(
+    "--include-private",
+    is_flag=True,
+    help="Include private repos from GitHub org (requires GITHUB_TOKEN)",
+)
+@click.option(
+    "--max-repos",
+    type=int,
+    default=100,
+    help="Maximum repos to assess from GitHub org (default: 100)",
+)
+@click.option(
     "--verbose",
     "-v",
     is_flag=True,
@@ -201,6 +216,9 @@ def _load_config(config_path: Path) -> Config:
 def assess_batch(
     repos_file: Optional[str],
     repos: tuple,
+    github_org: Optional[str],
+    include_private: bool,
+    max_repos: int,
     verbose: bool,
     output_dir: Optional[str],
     config: Optional[str],
@@ -209,13 +227,17 @@ def assess_batch(
 ):
     """Assess multiple repositories in a batch operation.
 
-    Supports two input methods:
+    Supports three input methods:
 
     1. File-based input:
         agentready assess-batch --repos-file repos.txt
 
     2. Inline arguments:
         agentready assess-batch --repos https://github.com/user/repo1 --repos https://github.com/user/repo2
+
+    3. GitHub organization:
+        agentready assess-batch --github-org anthropics
+        agentready assess-batch --github-org myorg --include-private --max-repos 50
 
     Output files are saved to .agentready/batch/ by default.
     """
@@ -236,9 +258,54 @@ def assess_batch(
     if repos:
         repository_urls.extend(repos)
 
+    # NEW: GitHub org scanning
+    if github_org:
+        try:
+            from ..services.github_scanner import (
+                GitHubAPIError,
+                GitHubAuthError,
+                GitHubOrgScanner,
+            )
+
+            scanner = GitHubOrgScanner()
+            org_repos = scanner.get_org_repos(
+                org_name=github_org,
+                include_private=include_private,
+                max_repos=max_repos,
+            )
+            repository_urls.extend(org_repos)
+
+            if verbose:
+                click.echo(f"Found {len(org_repos)} repositories in {github_org}")
+
+        except GitHubAuthError as e:
+            click.echo(f"GitHub authentication error: {e}", err=True)
+            sys.exit(1)
+
+        except GitHubAPIError as e:
+            click.echo(f"GitHub API error: {e}", err=True)
+            sys.exit(1)
+
+        except ValueError as e:
+            click.echo(f"Invalid input: {e}", err=True)
+            sys.exit(1)
+
+    # Remove duplicates while preserving order
+    if repository_urls:
+        seen = set()
+        unique_repos = []
+        for url in repository_urls:
+            if url not in seen:
+                seen.add(url)
+                unique_repos.append(url)
+        repository_urls = unique_repos
+
     # Validate we have repositories
     if not repository_urls:
-        click.echo("Error: No repositories specified. Use --repos-file or --repos", err=True)
+        click.echo(
+            "Error: No repositories specified. Use --repos-file, --repos, or --github-org",
+            err=True,
+        )
         sys.exit(1)
 
     if verbose:

--- a/src/agentready/services/github_scanner.py
+++ b/src/agentready/services/github_scanner.py
@@ -1,0 +1,229 @@
+"""GitHub organization scanner for discovering repositories.
+
+SECURITY REQUIREMENTS:
+- Token read from GITHUB_TOKEN environment variable only
+- Token format validated (ghp_...)
+- Token redacted in all logs and error messages
+- Token never stored in files or database
+- Organization name validated (alphanumeric + hyphens only)
+- Repository limit enforced (default: 100)
+- Rate limiting implemented
+- API errors caught and sanitized
+"""
+
+import logging
+import os
+import re
+import time
+from typing import List, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class GitHubAuthError(Exception):
+    """GitHub authentication errors."""
+
+    pass
+
+
+class GitHubAPIError(Exception):
+    """GitHub API errors."""
+
+    pass
+
+
+class GitHubOrgScanner:
+    """Discovers repositories from GitHub organizations.
+
+    SECURITY REQUIREMENTS:
+    - Token read from GITHUB_TOKEN environment variable only
+    - Token MUST be redacted in all logs/errors
+    - Enforce repository limit (default: 100)
+    - Implement rate limiting
+    - Validate org name (alphanumeric + hyphens only)
+    """
+
+    # GitHub token pattern (ghp_ followed by 36 alphanumeric characters)
+    TOKEN_PATTERN = re.compile(r"^ghp_[a-zA-Z0-9]{36}$")
+
+    # Organization name pattern (alphanumeric and hyphens, max 39 chars)
+    ORG_PATTERN = re.compile(r"^[a-zA-Z0-9-]{1,39}$")
+
+    def __init__(self, token: Optional[str] = None):
+        """Initialize GitHub scanner.
+
+        Args:
+            token: GitHub personal access token (optional, defaults to GITHUB_TOKEN env var)
+
+        Raises:
+            GitHubAuthError: If token is missing or invalid
+        """
+        self.token = token or os.getenv("GITHUB_TOKEN")
+
+        if not self.token:
+            raise GitHubAuthError(
+                "GITHUB_TOKEN environment variable required for GitHub org scanning.\n"
+                "Create a token at: https://github.com/settings/tokens\n"
+                "Required scopes: repo:status, public_repo"
+            )
+
+        self._validate_token_format()
+
+    def _validate_token_format(self):
+        """Validate GitHub token format.
+
+        SECURITY: Ensures token matches expected pattern
+        """
+        if not self.TOKEN_PATTERN.match(self.token):
+            raise GitHubAuthError(
+                "Invalid GitHub token format. Expected format: ghp_<36 characters>"
+            )
+
+    def _redact_token(self, text: str) -> str:
+        """Redact token from text for safe logging.
+
+        SECURITY: Prevents token exposure in logs/errors
+        """
+        if self.token in text:
+            return text.replace(self.token, "[REDACTED]")
+        return text
+
+    def get_org_repos(
+        self, org_name: str, include_private: bool = False, max_repos: int = 100
+    ) -> List[str]:
+        """Get all repository URLs from GitHub organization.
+
+        Args:
+            org_name: GitHub organization name
+            include_private: Include private repos (default: False)
+            max_repos: Maximum repositories to fetch (default: 100)
+
+        Returns:
+            List of git clone URLs (https)
+
+        Raises:
+            ValueError: If org name is invalid
+            GitHubAPIError: If API request fails
+
+        SECURITY:
+        - Validates org name (prevent injection)
+        - Enforces max_repos limit
+        - Redacts token in error messages
+        """
+        # SECURITY: Validate org name
+        if not self.ORG_PATTERN.match(org_name):
+            raise ValueError(
+                f"Invalid organization name: {org_name}\n"
+                "Organization names must contain only alphanumeric characters and hyphens"
+            )
+
+        logger.info(f"Scanning GitHub organization: {org_name}")
+
+        repos = []
+        page = 1
+        per_page = 100
+
+        while len(repos) < max_repos:
+            url = f"https://api.github.com/orgs/{org_name}/repos"
+            params = {
+                "page": page,
+                "per_page": per_page,
+                "type": "all" if include_private else "public",
+            }
+
+            try:
+                response = requests.get(
+                    url,
+                    headers={
+                        "Authorization": f"Bearer {self.token}",
+                        "Accept": "application/vnd.github.v3+json",
+                    },
+                    params=params,
+                    timeout=30,
+                )
+                response.raise_for_status()
+
+            except requests.Timeout:
+                raise GitHubAPIError(
+                    f"GitHub API timeout for organization: {org_name}"
+                )
+
+            except requests.HTTPError as e:
+                # SECURITY: Redact token before raising
+                safe_error = self._redact_token(str(e))
+
+                if response.status_code == 404:
+                    raise GitHubAPIError(
+                        f"Organization not found: {org_name}\n"
+                        "Verify the organization name is correct and your token has access"
+                    )
+                elif response.status_code == 401:
+                    raise GitHubAuthError(
+                        "GitHub authentication failed. Check your GITHUB_TOKEN"
+                    )
+                elif response.status_code == 403:
+                    # Check if rate limited
+                    if "rate limit" in response.text.lower():
+                        raise GitHubAPIError(
+                            "GitHub API rate limit exceeded. Try again later or use authentication"
+                        )
+                    raise GitHubAuthError(
+                        "GitHub authorization failed. Your token may lack required permissions"
+                    )
+                else:
+                    raise GitHubAPIError(f"GitHub API error: {safe_error}")
+
+            except requests.RequestException as e:
+                # SECURITY: Redact token before raising
+                safe_error = self._redact_token(str(e))
+                raise GitHubAPIError(f"GitHub API request failed: {safe_error}")
+
+            # Parse response
+            try:
+                batch = response.json()
+            except ValueError:
+                raise GitHubAPIError("Invalid JSON response from GitHub API")
+
+            # No more repos
+            if not batch:
+                break
+
+            # Filter and collect repos
+            for repo in batch:
+                # Skip private repos unless explicitly included
+                if not include_private and repo.get("private", False):
+                    continue
+
+                # Skip archived repos
+                if repo.get("archived", False):
+                    logger.info(f"Skipping archived repo: {repo['name']}")
+                    continue
+
+                clone_url = repo.get("clone_url")
+                if clone_url:
+                    repos.append(clone_url)
+
+                    if len(repos) >= max_repos:
+                        logger.warning(
+                            f"Reached repository limit ({max_repos}). "
+                            "Increase --max-repos to scan more repositories"
+                        )
+                        break
+
+            # Check rate limit headers
+            remaining = response.headers.get("X-RateLimit-Remaining")
+            if remaining and int(remaining) < 10:
+                logger.warning(
+                    f"GitHub API rate limit low: {remaining} requests remaining"
+                )
+
+            # Next page
+            page += 1
+
+            # SECURITY: Basic rate limiting (avoid hammering API)
+            time.sleep(0.2)
+
+        logger.info(f"Found {len(repos)} repositories in {org_name}")
+        return repos[:max_repos]

--- a/tests/integration/test_github_integration.py
+++ b/tests/integration/test_github_integration.py
@@ -1,0 +1,62 @@
+"""Integration tests for GitHub scanner (requires GITHUB_TOKEN)."""
+
+import os
+
+import pytest
+
+from agentready.services.github_scanner import GitHubOrgScanner
+
+
+@pytest.mark.skipif(not os.getenv("GITHUB_TOKEN"), reason="GITHUB_TOKEN not set")
+def test_real_github_org_scan():
+    """Integration test with real GitHub API (requires GITHUB_TOKEN).
+
+    Tests scanning a well-known public organization.
+    """
+    scanner = GitHubOrgScanner()
+
+    # Scan a well-known public org with a small limit
+    repos = scanner.get_org_repos("python", max_repos=5)
+
+    assert len(repos) > 0
+    assert len(repos) <= 5
+    assert all(url.startswith("https://") for url in repos)
+    assert all(url.endswith(".git") for url in repos)
+
+
+@pytest.mark.skipif(not os.getenv("GITHUB_TOKEN"), reason="GITHUB_TOKEN not set")
+def test_github_org_scan_filters_archived():
+    """Test that archived repos are filtered in real API calls."""
+    scanner = GitHubOrgScanner()
+
+    # Scan an org, check that no archived repos are included
+    repos = scanner.get_org_repos("python", max_repos=10)
+
+    # We can't easily verify archived status without making additional API calls,
+    # but at least verify we get valid repo URLs
+    assert all(isinstance(url, str) for url in repos)
+    assert all("github.com" in url for url in repos)
+
+
+@pytest.mark.skipif(not os.getenv("GITHUB_TOKEN"), reason="GITHUB_TOKEN not set")
+def test_github_org_scan_respects_limit():
+    """Test that max_repos limit is respected with real API."""
+    scanner = GitHubOrgScanner()
+
+    # Request only 3 repos
+    repos = scanner.get_org_repos("python", max_repos=3)
+
+    # Should get exactly 3 repos (or fewer if org has fewer repos)
+    assert len(repos) <= 3
+
+
+@pytest.mark.skipif(not os.getenv("GITHUB_TOKEN"), reason="GITHUB_TOKEN not set")
+def test_github_nonexistent_org():
+    """Test error handling for nonexistent organization."""
+    from agentready.services.github_scanner import GitHubAPIError
+
+    scanner = GitHubOrgScanner()
+
+    # Use a very unlikely org name
+    with pytest.raises(GitHubAPIError, match="Organization not found"):
+        scanner.get_org_repos("this-org-definitely-does-not-exist-12345")

--- a/tests/unit/test_github_scanner.py
+++ b/tests/unit/test_github_scanner.py
@@ -1,0 +1,455 @@
+"""Unit tests for GitHub organization scanner."""
+
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from agentready.services.github_scanner import (
+    GitHubAPIError,
+    GitHubAuthError,
+    GitHubOrgScanner,
+)
+
+
+def test_missing_token():
+    """Test that missing token raises error."""
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(GitHubAuthError, match="GITHUB_TOKEN"):
+            GitHubOrgScanner()
+
+
+def test_invalid_token_format():
+    """Test that invalid token format raises error."""
+    with patch.dict("os.environ", {"GITHUB_TOKEN": "invalid_token"}):
+        with pytest.raises(GitHubAuthError, match="Invalid GitHub token format"):
+            GitHubOrgScanner()
+
+
+def test_valid_token_format():
+    """Test that valid token format is accepted."""
+    token = "ghp_" + "a" * 36
+    with patch.dict("os.environ", {"GITHUB_TOKEN": token}):
+        scanner = GitHubOrgScanner()
+        assert scanner.token == token
+
+
+def test_invalid_org_name():
+    """Test that invalid org name raises error."""
+    token = "ghp_" + "a" * 36
+    with patch.dict("os.environ", {"GITHUB_TOKEN": token}):
+        scanner = GitHubOrgScanner()
+
+        # Test various invalid org names
+        invalid_names = [
+            "invalid org name!",  # Spaces
+            "org/name",  # Slashes
+            "org@name",  # Special characters
+            "a" * 40,  # Too long
+            "",  # Empty
+        ]
+
+        for invalid_name in invalid_names:
+            with pytest.raises(ValueError, match="Invalid organization name"):
+                scanner.get_org_repos(invalid_name)
+
+
+def test_valid_org_names():
+    """Test that valid org names are accepted."""
+    token = "ghp_" + "a" * 36
+
+    valid_names = [
+        "github",
+        "anthropics",
+        "my-org",
+        "org123",
+        "a",  # Single character
+        "a" * 39,  # Max length
+    ]
+
+    with patch.dict("os.environ", {"GITHUB_TOKEN": token}):
+        scanner = GitHubOrgScanner()
+
+        with patch("requests.get") as mock_get:
+            # Mock empty response (no repos)
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = []
+            mock_response.headers = {"X-RateLimit-Remaining": "5000"}
+            mock_get.return_value = mock_response
+
+            for valid_name in valid_names:
+                # Should not raise
+                repos = scanner.get_org_repos(valid_name)
+                assert repos == []
+
+
+def test_token_redaction():
+    """Test that token is redacted in error messages."""
+    token = "ghp_" + "a" * 36
+    with patch.dict("os.environ", {"GITHUB_TOKEN": token}):
+        scanner = GitHubOrgScanner()
+
+        # Test redaction
+        text = f"Error with token {token}"
+        redacted = scanner._redact_token(text)
+        assert token not in redacted
+        assert "[REDACTED]" in redacted
+
+        # Test no change if token not present
+        text_without_token = "Error without token"
+        assert scanner._redact_token(text_without_token) == text_without_token
+
+
+@patch("requests.get")
+def test_successful_org_scan(mock_get):
+    """Test successful organization scan."""
+    token = "ghp_" + "a" * 36
+
+    # Mock API response
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [
+        {
+            "name": "repo1",
+            "clone_url": "https://github.com/org/repo1.git",
+            "private": False,
+            "archived": False,
+        },
+        {
+            "name": "repo2",
+            "clone_url": "https://github.com/org/repo2.git",
+            "private": False,
+            "archived": False,
+        },
+    ]
+    mock_response.headers = {"X-RateLimit-Remaining": "5000"}
+    mock_get.return_value = mock_response
+
+    with patch.dict("os.environ", {"GITHUB_TOKEN": token}):
+        scanner = GitHubOrgScanner()
+        repos = scanner.get_org_repos("testorg")
+
+        assert len(repos) == 2
+        assert "https://github.com/org/repo1.git" in repos
+        assert "https://github.com/org/repo2.git" in repos
+
+
+@patch("requests.get")
+def test_filters_private_repos(mock_get):
+    """Test that private repos are filtered by default."""
+    token = "ghp_" + "a" * 36
+
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [
+        {
+            "name": "public-repo",
+            "clone_url": "https://github.com/org/public.git",
+            "private": False,
+            "archived": False,
+        },
+        {
+            "name": "private-repo",
+            "clone_url": "https://github.com/org/private.git",
+            "private": True,
+            "archived": False,
+        },
+    ]
+    mock_response.headers = {"X-RateLimit-Remaining": "5000"}
+    mock_get.return_value = mock_response
+
+    with patch.dict("os.environ", {"GITHUB_TOKEN": token}):
+        scanner = GitHubOrgScanner()
+        repos = scanner.get_org_repos("testorg", include_private=False)
+
+        assert len(repos) == 1
+        assert "https://github.com/org/public.git" in repos
+
+
+@patch("requests.get")
+def test_includes_private_repos_when_requested(mock_get):
+    """Test that private repos are included when requested."""
+    token = "ghp_" + "a" * 36
+
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [
+        {
+            "name": "public-repo",
+            "clone_url": "https://github.com/org/public.git",
+            "private": False,
+            "archived": False,
+        },
+        {
+            "name": "private-repo",
+            "clone_url": "https://github.com/org/private.git",
+            "private": True,
+            "archived": False,
+        },
+    ]
+    mock_response.headers = {"X-RateLimit-Remaining": "5000"}
+    mock_get.return_value = mock_response
+
+    with patch.dict("os.environ", {"GITHUB_TOKEN": token}):
+        scanner = GitHubOrgScanner()
+        repos = scanner.get_org_repos("testorg", include_private=True)
+
+        assert len(repos) == 2
+        assert "https://github.com/org/public.git" in repos
+        assert "https://github.com/org/private.git" in repos
+
+
+@patch("requests.get")
+def test_filters_archived_repos(mock_get):
+    """Test that archived repos are always filtered."""
+    token = "ghp_" + "a" * 36
+
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [
+        {
+            "name": "active-repo",
+            "clone_url": "https://github.com/org/active.git",
+            "private": False,
+            "archived": False,
+        },
+        {
+            "name": "archived-repo",
+            "clone_url": "https://github.com/org/archived.git",
+            "private": False,
+            "archived": True,
+        },
+    ]
+    mock_response.headers = {"X-RateLimit-Remaining": "5000"}
+    mock_get.return_value = mock_response
+
+    with patch.dict("os.environ", {"GITHUB_TOKEN": token}):
+        scanner = GitHubOrgScanner()
+        repos = scanner.get_org_repos("testorg")
+
+        assert len(repos) == 1
+        assert "https://github.com/org/active.git" in repos
+
+
+@patch("requests.get")
+def test_respects_max_repos_limit(mock_get):
+    """Test that max_repos limit is enforced."""
+    token = "ghp_" + "a" * 36
+
+    # Return 150 repos in one batch
+    mock_repos = [
+        {
+            "name": f"repo{i}",
+            "clone_url": f"https://github.com/org/repo{i}.git",
+            "private": False,
+            "archived": False,
+        }
+        for i in range(150)
+    ]
+
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = mock_repos
+    mock_response.headers = {"X-RateLimit-Remaining": "5000"}
+    mock_get.return_value = mock_response
+
+    with patch.dict("os.environ", {"GITHUB_TOKEN": token}):
+        scanner = GitHubOrgScanner()
+        repos = scanner.get_org_repos("testorg", max_repos=10)
+
+        assert len(repos) == 10
+
+
+@patch("requests.get")
+def test_pagination(mock_get):
+    """Test that pagination works correctly."""
+    token = "ghp_" + "a" * 36
+
+    # First page: 100 repos
+    page1_repos = [
+        {
+            "name": f"repo{i}",
+            "clone_url": f"https://github.com/org/repo{i}.git",
+            "private": False,
+            "archived": False,
+        }
+        for i in range(100)
+    ]
+
+    # Second page: 50 repos
+    page2_repos = [
+        {
+            "name": f"repo{i}",
+            "clone_url": f"https://github.com/org/repo{i}.git",
+            "private": False,
+            "archived": False,
+        }
+        for i in range(100, 150)
+    ]
+
+    # Third page: empty (no more repos)
+    page3_repos = []
+
+    responses = [page1_repos, page2_repos, page3_repos]
+    call_count = [0]
+
+    def mock_get_side_effect(*args, **kwargs):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = responses[call_count[0]]
+        mock_response.headers = {"X-RateLimit-Remaining": "5000"}
+        call_count[0] += 1
+        return mock_response
+
+    mock_get.side_effect = mock_get_side_effect
+
+    with patch.dict("os.environ", {"GITHUB_TOKEN": token}):
+        scanner = GitHubOrgScanner()
+        repos = scanner.get_org_repos("testorg", max_repos=200)
+
+        # Should get all 150 repos (stopped at empty page)
+        assert len(repos) == 150
+
+
+@patch("requests.get")
+def test_handles_404_org_not_found(mock_get):
+    """Test handling of 404 (org not found)."""
+    token = "ghp_" + "a" * 36
+
+    mock_response = Mock()
+    mock_response.status_code = 404
+    mock_response.raise_for_status.side_effect = requests.HTTPError()
+    mock_get.return_value = mock_response
+
+    with patch.dict("os.environ", {"GITHUB_TOKEN": token}):
+        scanner = GitHubOrgScanner()
+        with pytest.raises(GitHubAPIError, match="Organization not found"):
+            scanner.get_org_repos("nonexistent")
+
+
+@patch("requests.get")
+def test_handles_401_auth_failed(mock_get):
+    """Test handling of 401 (authentication failed)."""
+    token = "ghp_" + "a" * 36
+
+    mock_response = Mock()
+    mock_response.status_code = 401
+    mock_response.raise_for_status.side_effect = requests.HTTPError()
+    mock_get.return_value = mock_response
+
+    with patch.dict("os.environ", {"GITHUB_TOKEN": token}):
+        scanner = GitHubOrgScanner()
+        with pytest.raises(GitHubAuthError, match="authentication failed"):
+            scanner.get_org_repos("testorg")
+
+
+@patch("requests.get")
+def test_handles_403_rate_limit(mock_get):
+    """Test handling of 403 (rate limit exceeded)."""
+    token = "ghp_" + "a" * 36
+
+    mock_response = Mock()
+    mock_response.status_code = 403
+    mock_response.text = "API rate limit exceeded for user"
+    mock_response.raise_for_status.side_effect = requests.HTTPError()
+    mock_get.return_value = mock_response
+
+    with patch.dict("os.environ", {"GITHUB_TOKEN": token}):
+        scanner = GitHubOrgScanner()
+        with pytest.raises(GitHubAPIError, match="rate limit exceeded"):
+            scanner.get_org_repos("testorg")
+
+
+@patch("requests.get")
+def test_handles_403_authorization_failed(mock_get):
+    """Test handling of 403 (authorization failed, not rate limit)."""
+    token = "ghp_" + "a" * 36
+
+    mock_response = Mock()
+    mock_response.status_code = 403
+    mock_response.text = "Forbidden: insufficient permissions"
+    mock_response.raise_for_status.side_effect = requests.HTTPError()
+    mock_get.return_value = mock_response
+
+    with patch.dict("os.environ", {"GITHUB_TOKEN": token}):
+        scanner = GitHubOrgScanner()
+        with pytest.raises(GitHubAuthError, match="authorization failed"):
+            scanner.get_org_repos("testorg")
+
+
+@patch("requests.get")
+def test_handles_timeout(mock_get):
+    """Test handling of request timeout."""
+    token = "ghp_" + "a" * 36
+
+    mock_get.side_effect = requests.Timeout()
+
+    with patch.dict("os.environ", {"GITHUB_TOKEN": token}):
+        scanner = GitHubOrgScanner()
+        with pytest.raises(GitHubAPIError, match="timeout"):
+            scanner.get_org_repos("testorg")
+
+
+@patch("requests.get")
+def test_handles_invalid_json(mock_get):
+    """Test handling of invalid JSON response."""
+    token = "ghp_" + "a" * 36
+
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.side_effect = ValueError("Invalid JSON")
+    mock_get.return_value = mock_response
+
+    with patch.dict("os.environ", {"GITHUB_TOKEN": token}):
+        scanner = GitHubOrgScanner()
+        with pytest.raises(GitHubAPIError, match="Invalid JSON"):
+            scanner.get_org_repos("testorg")
+
+
+@patch("requests.get")
+def test_token_redacted_in_request_exception(mock_get):
+    """Test that token is redacted when RequestException contains it."""
+    token = "ghp_" + "a" * 36
+
+    # Simulate error message containing token
+    mock_get.side_effect = requests.RequestException(f"Connection error with {token}")
+
+    with patch.dict("os.environ", {"GITHUB_TOKEN": token}):
+        scanner = GitHubOrgScanner()
+        with pytest.raises(GitHubAPIError) as exc_info:
+            scanner.get_org_repos("testorg")
+
+        # Verify token is redacted in error message
+        error_msg = str(exc_info.value)
+        assert token not in error_msg
+        assert "[REDACTED]" in error_msg
+
+
+@patch("requests.get")
+def test_rate_limit_warning(mock_get, caplog):
+    """Test that low rate limit triggers warning."""
+    token = "ghp_" + "a" * 36
+
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [
+        {
+            "name": "repo1",
+            "clone_url": "https://github.com/org/repo1.git",
+            "private": False,
+            "archived": False,
+        }
+    ]
+    # Low rate limit
+    mock_response.headers = {"X-RateLimit-Remaining": "5"}
+    mock_get.return_value = mock_response
+
+    with patch.dict("os.environ", {"GITHUB_TOKEN": token}):
+        scanner = GitHubOrgScanner()
+        repos = scanner.get_org_repos("testorg")
+
+        assert len(repos) == 1
+        # Should have logged a warning about low rate limit
+        assert any("rate limit low" in record.message.lower() for record in caplog.records)


### PR DESCRIPTION
## Phase 3: Multi-Repository Assessment - GitHub Integration

Implements GitHub organization scanning for the `assess-batch` command.

### Features
- GitHub organization scanning via `--github-org` flag
- Public repos by default, private repos with `--include-private`
- Configurable repository limit (`--max-repos`, default: 100)
- Token authentication via GITHUB_TOKEN environment variable

### Security Controls
- Token read from environment only
- Token format validation (ghp_... pattern)
- Token redaction in all logs/errors
- Organization name validation (prevents injection)
- Repository limit enforcement
- Rate limiting (0.2s between requests)

### Testing
- Unit tests: 20+ tests covering all functionality
- Integration tests: Real GitHub API tests
- Security tests: Token security, injection prevention

### Files Changed
- `src/agentready/services/github_scanner.py` (new)
- `src/agentready/cli/assess_batch.py` (modified)
- `pyproject.toml` (added requests dependency)
- `CLAUDE.md` (documentation updated)
- Test files (new/modified)

Closes #70

---

🤖 Generated with [Claude Code](https://claude.ai/code)