### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/tests/integration/test_github_integration.py
+++ b/tests/integration/test_github_integration.py
@@ -3,6 +3,7 @@
 import os
 
 import pytest
+import urllib.parse
 
 from agentready.services.github_scanner import GitHubOrgScanner
 
@@ -35,7 +36,7 @@ def test_github_org_scan_filters_archived():
     # We can't easily verify archived status without making additional API calls,
     # but at least verify we get valid repo URLs
     assert all(isinstance(url, str) for url in repos)
-    assert all("github.com" in url for url in repos)
+    assert all(urllib.parse.urlparse(url).hostname == "github.com" for url in repos)
 
 
 @pytest.mark.skipif(not os.getenv("GITHUB_TOKEN"), reason="GITHUB_TOKEN not set")


### PR DESCRIPTION
Potential fix for [https://github.com/ambient-code/agentready/security/code-scanning/3](https://github.com/ambient-code/agentready/security/code-scanning/3)

The best way to fix this problem is to parse the URLs and assert that the hostname is exactly `github.com`. We can use Python's standard library `urllib.parse` to parse each URL and extract the `hostname`. We should then check that each parsed URL's hostname is equal to `"github.com"`. The assertion on line 38 in `tests/integration/test_github_integration.py` should be replaced accordingly.

Specifically:
- On line 38, replace `assert all("github.com" in url for url in repos)` with an assertion that checks each URL has hostname `"github.com"` using `urllib.parse.urlparse`.
- Add an import for `urllib.parse` (if not already present in the code region shown).
- This change should be limited to the test assertion; other logic need not change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
