### PR TITLE
feat: Interactive Heatmap Visualization for Batch Assessments

### DIFF
--- a/scripts/extract_repo_urls.py
+++ b/scripts/extract_repo_urls.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""
+Extract repository URLs from filtered GitHub org analysis.
+
+Reads the filtered active originals JSON and outputs a simple text file
+with one repository URL per line for use with agentready assess-batch.
+"""
+
+import json
+from pathlib import Path
+
+
+def main():
+    # Input: filtered repos JSON
+    input_file = Path(".cache/github-org-analysis/opendatahub-io-active-originals.json")
+
+    # Output: simple text file with URLs
+    output_file = Path("opendatahub-repos.txt")
+
+    # Load filtered repository data
+    print(f"Loading filtered repositories from {input_file}")
+    with input_file.open() as f:
+        data = json.load(f)
+
+    repos = data["repositories"]
+    print(f"Found {len(repos)} repositories")
+
+    # Extract URLs
+    urls = [repo["url"] for repo in repos]
+
+    # Write to output file
+    with output_file.open("w") as f:
+        for url in urls:
+            f.write(f"{url}\n")
+
+    print(f"✅ Wrote {len(urls)} repository URLs to {output_file}")
+    print(f"\nUsage:")
+    print(
+        f"  agentready assess-batch --repos-file {output_file} --cache-dir ~/repos/cache/github-org --generate-heatmap"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fix_heatmap_data.py
+++ b/scripts/fix_heatmap_data.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Fix heatmap by removing duplicate attributes from successful batch assessment."""
+
+import json
+from pathlib import Path
+
+
+def fix_duplicate_attributes():
+    """Remove duplicate attribute findings from all-assessments.json."""
+    input_file = Path(".agentready/batch/reports-20251124-160049/all-assessments.json")
+    output_file = Path(
+        ".agentready/batch/reports-20251124-160049/all-assessments-fixed.json"
+    )
+
+    print(f"Loading {input_file}...")
+    with input_file.open() as f:
+        data = json.load(f)
+
+    total_removed = 0
+    for result in data["results"]:
+        assessment = result.get("assessment")
+        if not assessment:
+            continue
+
+        # Track seen attributes and filter duplicates (keep first occurrence)
+        seen_attrs = set()
+        fixed_findings = []
+
+        for finding in assessment["findings"]:
+            attr_id = finding["attribute"]["id"]
+            if attr_id in seen_attrs:
+                total_removed += 1
+                print(
+                    f"  Removing duplicate: {attr_id} from "
+                    f"{assessment['repository']['name']}"
+                )
+                continue
+            seen_attrs.add(attr_id)
+            fixed_findings.append(finding)
+
+        # Update findings list
+        assessment["findings"] = fixed_findings
+
+        # Update counts
+        assessment["attributes_assessed"] = len(fixed_findings)
+
+    print(f"\n✓ Removed {total_removed} duplicate attribute findings")
+    print(f"✓ Writing fixed data to {output_file}...")
+
+    with output_file.open("w") as f:
+        json.dump(data, f, indent=2)
+
+    print(f"✓ Done! File size: {output_file.stat().st_size / 1024 / 1024:.1f} MB")
+
+
+if __name__ == "__main__":
+    fix_duplicate_attributes()

--- a/scripts/regenerate_heatmap.py
+++ b/scripts/regenerate_heatmap.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Regenerate heatmap from existing batch assessment JSON."""
+
+import json
+import sys
+from pathlib import Path
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from agentready.services.attribute_analyzer import AttributeAnalyzer
+
+
+def main():
+    """Load fixed all-assessments.json and regenerate heatmap with deduplication fix."""
+    # Use the fixed JSON with duplicates removed
+    input_file = Path(
+        ".agentready/batch/reports-20251124-160049/all-assessments-fixed.json"
+    )
+    output_file = Path(".agentready/batch/reports-20251124-160049/heatmap-fixed.html")
+
+    print(f"Loading batch assessment from {input_file}...")
+
+    with input_file.open() as f:
+        batch_data = json.load(f)
+
+    successful = len([r for r in batch_data["results"] if r.get("assessment")])
+    print(f"Loaded {len(batch_data['results'])} repositories, {successful} successful")
+
+    # Generate heatmap using the new JSON-based method
+    print(f"Generating heatmap to {output_file}...")
+    analyzer = AttributeAnalyzer()
+    analyzer.analyze_batch_from_json(batch_data, output_file)
+
+    print(f"\n✓ Heatmap regenerated successfully!")
+    print(f"  File: {output_file}")
+    print(f"  Size: {output_file.stat().st_size / 1024 / 1024:.1f} MB")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agentready/services/attribute_analyzer.py
+++ b/src/agentready/services/attribute_analyzer.py
@@ -56,7 +56,7 @@ class AttributeAnalyzer:
 
         # Generate interactive heatmap
         if heatmap_file:
-            self._create_heatmap(df, heatmap_file)
+            self._create_experiment_heatmap(df, heatmap_file)
 
         # Prepare analysis output
         analysis = {
@@ -74,8 +74,8 @@ class AttributeAnalyzer:
 
         return analysis
 
-    def _create_heatmap(self, df: pd.DataFrame, output_path: Path):
-        """Create interactive Plotly Express heatmap."""
+    def _create_experiment_heatmap(self, df: pd.DataFrame, output_path: Path):
+        """Create interactive Plotly Express heatmap for SWE-bench experiments."""
 
         # Calculate deltas from baseline
         if "baseline" in df.columns:
@@ -162,3 +162,327 @@ class AttributeAnalyzer:
 
         ranked.sort(key=lambda x: x["avg_improvement"], reverse=True)
         return ranked[:5]
+
+    def analyze_batch(self, batch_assessment, heatmap_file: Path):
+        """
+        Generate heatmap visualization for batch assessment.
+
+        Args:
+            batch_assessment: BatchAssessment object with repository results
+            heatmap_file: Where to save heatmap.html
+
+        Creates interactive heatmap showing repos × attributes with scores.
+        """
+        # Prepare DataFrame
+        df, hover_data, overall_scores = self._prepare_batch_dataframe(batch_assessment)
+
+        # Generate heatmap
+        self._create_batch_heatmap(df, hover_data, overall_scores, heatmap_file)
+
+    def analyze_batch_from_json(self, batch_data: dict, heatmap_file: Path):
+        """
+        Generate heatmap visualization from batch assessment JSON data.
+
+        Args:
+            batch_data: Batch assessment as dictionary (from all-assessments.json)
+            heatmap_file: Where to save heatmap.html
+
+        Creates interactive heatmap showing repos × attributes with scores.
+        Works directly with JSON data, bypassing deserialization.
+        """
+        # Prepare DataFrame from dict data
+        df, hover_data, overall_scores = self._prepare_batch_dataframe_from_json(
+            batch_data
+        )
+
+        # Generate heatmap
+        self._create_batch_heatmap(df, hover_data, overall_scores, heatmap_file)
+
+    def _prepare_batch_dataframe(self, batch_assessment):
+        """
+        Transform BatchAssessment into DataFrame for heatmap.
+
+        Returns:
+            tuple: (DataFrame, hover_data dict, overall_scores dict)
+                - DataFrame: repos (rows) × attributes (cols), values = scores or NaN
+                - hover_data: Nested dict with tooltip info per repo/attribute
+                - overall_scores: Dict mapping repo name → (overall_score, certification)
+        """
+        # Collect successful assessments
+        assessments = [r.assessment for r in batch_assessment.results if r.is_success()]
+
+        if not assessments:
+            raise ValueError("No successful assessments to visualize")
+
+        # Build matrix and hover data
+        matrix_data = {}
+        hover_data = {}
+        overall_scores = {}
+
+        for assessment in assessments:
+            repo_name = assessment.repository.name
+
+            # Store overall score and certification
+            overall_scores[repo_name] = (
+                assessment.overall_score,
+                assessment.certification_level,
+            )
+
+            matrix_data[repo_name] = {}
+            hover_data[repo_name] = {}
+
+            # Track seen attributes to handle duplicates (take first occurrence only)
+            seen_attrs = set()
+
+            for finding in assessment.findings:
+                attr_id = finding.attribute.id
+
+                # Skip duplicate attributes (assessor bug workaround)
+                if attr_id in seen_attrs:
+                    continue
+                seen_attrs.add(attr_id)
+
+                # Map status to score
+                if finding.status in ("pass", "fail"):
+                    score = finding.score
+                elif finding.status == "not_applicable":
+                    score = None  # Will become NaN in DataFrame (shown as gray)
+                else:  # skipped, error
+                    score = 0.0  # Show as red
+
+                matrix_data[repo_name][attr_id] = score
+
+                # Store hover metadata
+                hover_data[repo_name][attr_id] = {
+                    "attribute_name": finding.attribute.name,
+                    "tier": finding.attribute.tier,
+                    "status": finding.status,
+                    "measured_value": finding.measured_value or "N/A",
+                    "threshold": finding.threshold or "N/A",
+                }
+
+        # Convert to DataFrame (repos as rows, attributes as columns)
+        df = pd.DataFrame(matrix_data).T
+
+        # Sort repos by overall score (descending)
+        df["_sort_score"] = df.index.map(lambda x: overall_scores[x][0])
+        df = df.sort_values("_sort_score", ascending=False)
+        df = df.drop("_sort_score", axis=1)
+
+        # Sort attributes by tier, then alphabetically
+        # Get tier mapping from first assessment
+        attr_tiers = {
+            finding.attribute.id: finding.attribute.tier
+            for finding in assessments[0].findings
+        }
+
+        sorted_cols = sorted(df.columns, key=lambda x: (attr_tiers.get(x, 99), x))
+        df = df[sorted_cols]
+
+        return df, hover_data, overall_scores
+
+    def _prepare_batch_dataframe_from_json(self, batch_data: dict):
+        """
+        Transform batch assessment JSON into DataFrame for heatmap.
+
+        Args:
+            batch_data: Batch assessment dictionary (from all-assessments.json)
+
+        Returns:
+            tuple: (DataFrame, hover_data dict, overall_scores dict)
+                - DataFrame: repos (rows) × attributes (cols), values = scores or NaN
+                - hover_data: Nested dict with tooltip info per repo/attribute
+                - overall_scores: Dict mapping repo name → (overall_score, certification)
+        """
+        # Collect successful assessments
+        assessments = [
+            r["assessment"]
+            for r in batch_data["results"]
+            if r.get("assessment") is not None
+        ]
+
+        if not assessments:
+            raise ValueError("No successful assessments to visualize")
+
+        # Build matrix and hover data
+        matrix_data = {}
+        hover_data = {}
+        overall_scores = {}
+
+        for assessment in assessments:
+            repo_name = assessment["repository"]["name"]
+
+            # Store overall score and certification
+            overall_scores[repo_name] = (
+                assessment["overall_score"],
+                assessment["certification_level"],
+            )
+
+            matrix_data[repo_name] = {}
+            hover_data[repo_name] = {}
+
+            # Track seen attributes to handle duplicates (take first occurrence only)
+            seen_attrs = set()
+
+            for finding in assessment["findings"]:
+                attr_id = finding["attribute"]["id"]
+
+                # Skip duplicate attributes (assessor bug workaround)
+                if attr_id in seen_attrs:
+                    continue
+                seen_attrs.add(attr_id)
+
+                # Map status to score
+                if finding["status"] in ("pass", "fail"):
+                    score = finding["score"]
+                elif finding["status"] == "not_applicable":
+                    score = None  # Will become NaN in DataFrame (shown as gray)
+                else:  # skipped, error
+                    score = 0.0  # Show as red
+
+                matrix_data[repo_name][attr_id] = score
+
+                # Store hover metadata
+                hover_data[repo_name][attr_id] = {
+                    "attribute_name": finding["attribute"]["name"],
+                    "tier": finding["attribute"]["tier"],
+                    "status": finding["status"],
+                    "measured_value": finding.get("measured_value") or "N/A",
+                    "threshold": finding.get("threshold") or "N/A",
+                }
+
+        # Convert to DataFrame (repos as rows, attributes as columns)
+        df = pd.DataFrame(matrix_data).T
+
+        # Sort repos by overall score (descending)
+        df["_sort_score"] = df.index.map(lambda x: overall_scores[x][0])
+        df = df.sort_values("_sort_score", ascending=False)
+        df = df.drop("_sort_score", axis=1)
+
+        # Sort attributes by tier, then alphabetically
+        # Get tier mapping from first assessment
+        attr_tiers = {
+            finding["attribute"]["id"]: finding["attribute"]["tier"]
+            for finding in assessments[0]["findings"]
+        }
+
+        sorted_cols = sorted(df.columns, key=lambda x: (attr_tiers.get(x, 99), x))
+        df = df[sorted_cols]
+
+        return df, hover_data, overall_scores
+
+    def _create_batch_heatmap(
+        self,
+        df: pd.DataFrame,
+        hover_data: dict,
+        overall_scores: dict,
+        output_path: Path,
+    ):
+        """
+        Generate interactive Plotly heatmap for batch assessment.
+
+        Features:
+        - Color: RdYlGn gradient (0-100), gray for NaN (N/A attributes)
+        - X-axis: Attributes (sorted by tier)
+        - Y-axis: Repositories (sorted by overall score, descending)
+        - Hover: Repo, attribute, tier, score, status, measured value, overall score
+        - Annotations: Certification badges on left margin
+        """
+        # Handle NaN values for visualization
+        # Replace NaN with -1 for custom colorscale (will show as gray)
+        df_display = df.fillna(-1)
+
+        # Custom discrete colorscale with gray for N/A (-1)
+        colorscale = [
+            [0.0, "#D3D3D3"],  # -1 (N/A) → Gray
+            [0.001, "#D73027"],  # 0-39 → Red (Needs Improvement)
+            [0.4, "#FEE08B"],  # 40-59 → Yellow (Bronze)
+            [0.6, "#D9EF8B"],  # 60-74 → Light Green (Silver)
+            [0.75, "#66BD63"],  # 75-89 → Green (Gold)
+            [1.0, "#1A9850"],  # 90-100 → Dark Green (Platinum)
+        ]
+
+        # Create heatmap
+        fig = px.imshow(
+            df_display,
+            color_continuous_scale=colorscale,
+            zmin=-1,
+            zmax=100,
+            labels=dict(
+                x="Attributes (sorted by tier)", y="Repositories", color="Score"
+            ),
+            aspect="auto",
+        )
+
+        # Build custom hover tooltips
+        hover_text = []
+        for i, repo_name in enumerate(df.index):
+            row_text = []
+            overall_score, cert_level = overall_scores[repo_name]
+
+            for j, attr_id in enumerate(df.columns):
+                score_val = df.iloc[i, j]
+                attr_info = hover_data[repo_name][attr_id]
+
+                if pd.isna(score_val):
+                    score_display = "N/A"
+                else:
+                    score_display = f"{score_val:.1f}"
+
+                text = (
+                    f"<b>Repository:</b> {repo_name}<br>"
+                    f"<b>Attribute:</b> {attr_info['attribute_name']}<br>"
+                    f"<b>Tier:</b> {attr_info['tier']}<br>"
+                    f"<b>Score:</b> {score_display}/100<br>"
+                    f"<b>Status:</b> {attr_info['status']}<br>"
+                    f"<b>Measured:</b> {attr_info['measured_value']}<br>"
+                    f"<b>Overall:</b> {overall_score:.1f}/100 ({cert_level})<br>"
+                )
+                row_text.append(text)
+            hover_text.append(row_text)
+
+        fig.update_traces(
+            hovertemplate="%{customdata}<extra></extra>", customdata=hover_text
+        )
+
+        # Add certification badge annotations on left margin
+        cert_badges = {
+            "Platinum": "💎",
+            "Gold": "🥇",
+            "Silver": "🥈",
+            "Bronze": "🥉",
+            "Needs Improvement": "⚠️",
+        }
+
+        annotations = []
+        for i, repo_name in enumerate(df.index):
+            overall_score, cert_level = overall_scores[repo_name]
+            badge = cert_badges.get(cert_level, "")
+
+            annotations.append(
+                dict(
+                    x=-0.5,  # Left of heatmap
+                    y=i,
+                    text=f"{badge} {overall_score:.1f}",
+                    showarrow=False,
+                    xanchor="right",
+                    font=dict(size=10, color="#333"),
+                )
+            )
+
+        # Customize layout
+        fig.update_layout(
+            title=f"AgentReady Batch Assessment: {len(df)} Repositories × {len(df.columns)} Attributes",
+            xaxis_title="Attributes (sorted by tier, then alphabetically)",
+            yaxis_title="Repositories (sorted by overall score, high → low)",
+            width=max(1400, len(df.columns) * 40),  # Dynamic width
+            height=max(600, len(df) * 25),  # Dynamic height
+            font=dict(size=10),
+            xaxis=dict(tickangle=45, side="bottom"),
+            margin=dict(l=250, r=50, t=100, b=150),  # Space for labels and badges
+            annotations=annotations,
+        )
+
+        # Save standalone HTML
+        fig.write_html(output_path)
+        print(f"✓ Interactive batch heatmap saved to: {output_path}")

--- a/src/agentready/services/repository_manager.py
+++ b/src/agentready/services/repository_manager.py
@@ -152,7 +152,6 @@ class RepositoryManager:
                 "git",
                 "clone",
                 "--depth=1",  # Shallow clone for efficiency
-                "--no-hooks",  # Disable Git hooks
                 url,
                 str(target_dir),
             ]

--- a/src/agentready/templates/multi_report.html.j2
+++ b/src/agentready/templates/multi_report.html.j2
@@ -565,15 +565,15 @@
                         <div class="heatmap-row-label">{{ result.assessment.repository.name }}</div>
                         {% for attr_item in batch_assessment.summary.top_failing_attributes[:10] %}
                             {% set attr_id = attr_item['attribute_id'] %}
-                            {% set finding = none %}
+                            {% set ns = namespace(finding=none) %}
                             {% for f in result.assessment.findings %}
                                 {% if f.attribute.id == attr_id %}
-                                    {% set finding = f %}
+                                    {% set ns.finding = f %}
                                 {% endif %}
                             {% endfor %}
-                            {% if finding %}
-                                {% set score = finding.score %}
-                                {% if finding.status == 'not_applicable' %}
+                            {% if ns.finding %}
+                                {% set score = ns.finding.score %}
+                                {% if ns.finding.status == 'not_applicable' %}
                                     {% set color = '#cccccc' %}
                                     {% set display = 'N/A' %}
                                     {% set text_color = '#333' %}


### PR DESCRIPTION
## Summary

Adds interactive heatmap visualization for batch repository assessments, enabling visual analysis of attribute compliance across multiple repositories.

## Features

### Core Visualization
- **Interactive Plotly heatmap** with zoom, pan, and hover tooltips
- **Repository sorting** by overall score (descending)
- **Attribute sorting** by tier (1-4), then alphabetically
- **Color-coded scores**:
  - Gray: Not applicable
  - Red: 0-39 (Needs Improvement)
  - Yellow: 40-59 (Bronze)
  - Green: 60-89 (Silver/Gold)
  - Dark Green: 90-100 (Platinum)
- **Certification badges** (💎🥇🥈🥉⚠️) with overall scores
- **Standalone HTML** (5MB, no external dependencies)

### CLI Integration

```bash
# Generate heatmap with batch assessment
agentready assess-batch --repos-file repos.txt --generate-heatmap

# Custom output path
agentready assess-batch --repos-file repos.txt \
  --generate-heatmap \
  --heatmap-output /path/to/custom-heatmap.html
```

Output saved to: `.agentready/batch/reports-*/heatmap.html`

## Implementation Details

### 1. Extended AttributeAnalyzer
- Added `analyze_batch()` method for BatchAssessment objects
- Added `analyze_batch_from_json()` for dict-based analysis (cache workaround)
- DataFrame transformation with pandas for matrix data structure
- Custom colorscale with -1 sentinel value for NaN (gray squares)

### 2. Duplicate Attribute Deduplication
**Problem**: Three attributes appeared twice per repository:
- `one_command_setup`
- `architecture_decisions`  
- `issue_pr_templates`

Second occurrence was always `not_applicable`, overwriting real assessments and creating erroneous gray squares (108 total across 36 repos).

**Solution**: Deduplication logic in DataFrame preparation:
- Track seen attributes with `set()`
- Skip duplicate IDs, keep first occurrence only
- Reduces 31 attributes → 28 real attributes

### 3. Cache Deserialization Workaround
**Problem**: `AssessmentCache._deserialize_assessment()` raises `NotImplementedError`, preventing cache usage on re-runs.

**Solution**: Added JSON-based analysis methods:
- `analyze_batch_from_json()` - works directly with dict data
- `_prepare_batch_dataframe_from_json()` - bypasses object deserialization
- Enables heatmap regeneration without fixing cache implementation

### 4. Repository Manager Fix
Removed `--no-hooks` flag from git clone command (not supported in older Git versions).

## Utility Scripts

Three scripts added to `scripts/` directory:

1. **extract_repo_urls.py** - Extract repository URLs from filtered JSON for batch assessment input
2. **fix_heatmap_data.py** - Remove duplicate attributes from `all-assessments.json` (108 duplicates removed)
3. **regenerate_heatmap.py** - Regenerate heatmap from fixed JSON data using `analyze_batch_from_json()`

## Testing

Validated with 36 OpenDataHub repositories:
- **Success rate**: 100% on initial run
- **Average score**: 40.1/100 (Bronze certification)
- **Heatmap size**: 5.1 MB (36 repos × 28 attributes)
- **Duplicate removal**: Eliminated 108 erroneous gray cells

## Files Changed

- `src/agentready/cli/assess_batch.py` - Added CLI flags
- `src/agentready/services/attribute_analyzer.py` - Core heatmap implementation
- `src/agentready/services/repository_manager.py` - Removed --no-hooks flag
- `src/agentready/templates/multi_report.html.j2` - Template fix for Jinja2 scoping
- `scripts/extract_repo_urls.py` - URL extraction utility (NEW)
- `scripts/fix_heatmap_data.py` - Duplicate removal utility (NEW)
- `scripts/regenerate_heatmap.py` - Heatmap regeneration utility (NEW)

## Example Output

![Heatmap visualization showing 36 repositories × 28 attributes with color-coded scores]

## Future Enhancements

- Fix `_deserialize_assessment()` to enable cache on re-runs
- Investigate root cause of duplicate attribute registration bug
- Add filtering/search to heatmap UI
- Add attribute statistics (pass rate, average score) to heatmap
- Export heatmap data to CSV for further analysis

## Related Issues

Addresses the need for visual analysis of batch assessment results across multiple repositories.