### PR TITLE
fix: add uv.lock to recognized lockfiles

### DIFF
--- a/src/agentready/assessors/stub_assessors.py
+++ b/src/agentready/assessors/stub_assessors.py
@@ -40,6 +40,7 @@ class LockFilesAssessor(BaseAssessor):
             "pnpm-lock.yaml",
             "poetry.lock",
             "Pipfile.lock",
+            "uv.lock",
             "requirements.txt",
             "Cargo.lock",
             "Gemfile.lock",


### PR DESCRIPTION
Fixes #137

The LockFilesAssessor was missing uv.lock in its list of recognized lockfiles. This caused repositories using uv (Python's modern dependency manager) to incorrectly fail the lock files assessment.

## Changes
- Added `uv.lock` to the lockfiles list in `src/agentready/assessors/stub_assessors.py`

## Testing
Tested against https://github.com/libranet/autoread-dotenv which has a uv.lock file.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced lock file detection to recognize uv.lock format, improving assessment accuracy for projects using modern dependency management tooling. The system now validates reproducible dependencies across a broader range of project configurations and package managers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->