### PR TITLE
Automate package discovery in setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,9 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
-packages = ["agentready", "agentready.cli", "agentready.assessors", "agentready.models", "agentready.services", "agentready.reporters", "agentready.learners", "agentready.utils", "agentready.fixers", "agentready.github"]
+
+[tool.setuptools.packages.find]
+where = ["src"]
 
 [tool.setuptools.package-data]
 agentready = [


### PR DESCRIPTION
## Summary

Replace manual package list with automated package discovery to prevent future packaging bugs.

## Changes

1. **Automated Package Discovery** (`83603e9`)
   - Replaced manual `packages = [...]` list with `[tool.setuptools.packages.find]`
   - Configuration: `where = ["src"]` - automatically discovers all packages under `src/`
   - Follows modern Python packaging best practices (PEP 517)

2. **Fix Missing Packages** (`4741b23`)
   - Added `agentready.utils` to distribution (was missing)
   - Added `agentready.fixers` to distribution (was missing)
   - Added `agentready.github` to distribution (was missing)
   - Version bump to 2.11.2 for TestPyPI release

## Motivation

During TestPyPI publishing, discovered that 3 packages (`utils`, `fixers`, `github`) were missing from the distribution because they weren't in the manual package list. This caused import errors for users installing from PyPI.

## Solution

Use setuptools' built-in package discovery instead of manual enumeration. Any new package added under `src/agentready/` will now be automatically included in distributions.

## Validation

✅ All 10 packages verified in wheel distribution:
- agentready (main)
- assessors, cli, fixers, github, learners, models, reporters, services, utils

✅ Twine validation: Both wheel and source distribution PASSED

✅ Fresh installation test: All CLI commands work correctly
- `agentready --version` → v2.11.2
- `agentready assess --help` → Works
- `agentready bootstrap --help` → Works

✅ TestPyPI publication successful: https://test.pypi.org/project/agentready/2.11.2/

## Testing

Tested by:
1. Building package locally (`python -m build`)
2. Verifying wheel contents (`unzip -l`)
3. Fresh venv installation from wheel
4. Smoke tests of all CLI commands
5. Publishing to TestPyPI and validating installation

## Benefits

- **Prevents future bugs**: New packages automatically included
- **Less maintenance**: No manual updates when adding modules
- **Standard practice**: Follows setuptools recommendations
- **Future-proof**: Works with any new packages under `src/agentready/`

## Breaking Changes

None - produces identical distribution to manual list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)