### PR TITLE
feat: automate PyPI publishing with trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write  # Required for trusted publishing to PyPI
 
 jobs:
   release:
@@ -31,7 +32,54 @@ jobs:
         run: |
           npm install -g semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/github @semantic-release/exec
 
+      - name: Get version before release
+        id: version_before
+        run: echo "version=$(grep '^version = ' pyproject.toml | cut -d'"' -f2)" >> $GITHUB_OUTPUT
+
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release
+
+      - name: Get version after release
+        id: version_after
+        run: echo "version=$(grep '^version = ' pyproject.toml | cut -d'"' -f2)" >> $GITHUB_OUTPUT
+
+      - name: Check if new release
+        id: check_release
+        run: |
+          if [ "${{ steps.version_before.outputs.version }}" != "${{ steps.version_after.outputs.version }}" ]; then
+            echo "new_release=true" >> $GITHUB_OUTPUT
+            echo "version=${{ steps.version_after.outputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "new_release=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up Python
+        if: steps.check_release.outputs.new_release == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build dependencies
+        if: steps.check_release.outputs.new_release == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        if: steps.check_release.outputs.new_release == 'true'
+        run: |
+          python -m build
+          echo "📦 Built distribution files:"
+          ls -lh dist/
+
+      - name: Publish to Test PyPI
+        if: steps.check_release.outputs.new_release == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Publish to PyPI
+        if: steps.check_release.outputs.new_release == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Automates PyPI publishing as part of the release workflow using OIDC trusted publishing (no tokens required).

## Changes

- **Add OIDC permission**: `id-token: write` for trusted publishing
- **Version detection**: Compare version before/after semantic-release
- **Automated publishing**: Use `pypa/gh-action-pypi-publish@release/v1`
- **Dual publishing**: Publishes to Test PyPI first, then production PyPI
- **Conditional execution**: Only runs when semantic-release creates new version

## Benefits

- **No tokens**: Uses GitHub's OIDC for secure authentication
- **Fully automated**: No manual workflow trigger required
- **Safer**: Test PyPI validation before production
- **Signed attestations**: Automatic Sigstore attestations (2025 default)

## Testing

This PR will trigger the release workflow when merged. The workflow will:

1. Run semantic-release (analyze commits since v2.9.0)
2. Create new version tag (likely v2.10.0 based on merged features)
3. Build Python package
4. Publish to Test PyPI
5. Publish to production PyPI

## References

- [PyPI Trusted Publishing Docs](https://docs.pypi.org/trusted-publishers/)
- [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)