### PR TITLE
fix: disable attestations for Test PyPI to avoid conflict

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,10 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          attestations: false  # Disable to avoid conflict with production PyPI
 
       - name: Publish to PyPI
         if: steps.check_release.outputs.new_release == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true  # Enable attestations for production


### PR DESCRIPTION
## Problem

The release workflow (#154) failed when publishing to production PyPI with error:
```
Attestation generation failure: The following distributions already have publish attestations:
* /github/workspace/dist/agentready-2.12.0-py3-none-any.whl.publish.attestation
* /github/workspace/dist/agentready-2.12.0.tar.gz.publish.attestation
```

## Root Cause

The `pypa/gh-action-pypi-publish` action creates `.publish.attestation` files during the first publish (Test PyPI). When we try to publish to production PyPI in the same workflow run, it attempts to create attestation files again, causing a conflict.

## Solution

- Disable attestations for Test PyPI (we don't need them for testing)
- Keep attestations enabled for production PyPI (required for security)

## Testing

This fix allows the workflow to:
1. Publish to Test PyPI without attestations
2. Publish to production PyPI with attestations
3. No file conflicts between the two publish steps

## Result

After merging, the next release will successfully publish v2.12.0 (or next version) to both Test PyPI and production PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)