### PR TITLE
docs: add CLI reference and update AI bubble snark

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -227,6 +227,18 @@ pre code {
   text-decoration: none;
 }
 
+.button-tertiary {
+  background-color: var(--color-gray-100);
+  color: var(--color-gray-700);
+  border: 1px solid var(--color-gray-300);
+}
+
+.button-tertiary:hover {
+  background-color: var(--color-gray-200);
+  text-decoration: none;
+  border-color: var(--color-gray-400);
+}
+
 .button-large {
   padding: var(--space-4) var(--space-8);
   font-size: var(--text-lg);
@@ -509,37 +521,163 @@ hr {
 }
 
 /* ============================================
-   Navigation (if using custom navigation)
+   Navigation
    ============================================ */
 
-nav {
+header {
   background-color: var(--color-gray-900);
   color: white;
-  padding: var(--space-4) 0;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
 }
 
-nav ul {
+nav {
+  padding: 0;
+}
+
+.nav-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-4) var(--space-6);
+}
+
+/* Brand */
+.nav-brand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  text-decoration: none;
+  font-weight: 700;
+  font-size: var(--text-lg);
+  color: white;
+  transition: opacity 0.2s ease;
+}
+
+.nav-brand:hover {
+  opacity: 0.9;
+  text-decoration: none;
+}
+
+.brand-icon {
+  font-size: var(--text-2xl);
+}
+
+.brand-text {
+  letter-spacing: -0.02em;
+}
+
+/* Menu */
+.nav-menu {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
-  gap: var(--space-6);
-  justify-content: center;
-  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
 }
 
-nav a {
-  color: white;
+.nav-item {
+  position: relative;
+}
+
+.nav-link {
+  color: rgba(255, 255, 255, 0.9);
   text-decoration: none;
   font-weight: 500;
+  font-size: var(--text-sm);
   padding: var(--space-2) var(--space-4);
-  border-radius: var(--radius-sm);
-  transition: background-color 0.2s ease;
+  border-radius: var(--radius-md);
+  display: block;
+  transition: all 0.2s ease;
+  white-space: nowrap;
 }
 
-nav a:hover {
+.nav-link:hover {
   background-color: rgba(255, 255, 255, 0.1);
+  color: white;
   text-decoration: none;
+}
+
+/* Dropdown */
+.nav-dropdown {
+  position: relative;
+}
+
+.nav-dropdown > .nav-link {
+  cursor: pointer;
+}
+
+.dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background-color: white;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-xl);
+  margin-top: var(--space-2);
+  min-width: 200px;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-10px);
+  transition: all 0.2s ease;
+  list-style: none;
+  padding: var(--space-2);
+  z-index: 1001;
+}
+
+.nav-dropdown:hover .dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.dropdown-menu li {
+  margin: 0;
+}
+
+.dropdown-menu a {
+  color: var(--color-gray-700);
+  text-decoration: none;
+  padding: var(--space-2) var(--space-4);
+  display: block;
+  border-radius: var(--radius-sm);
+  transition: background-color 0.2s ease;
+  font-size: var(--text-sm);
+}
+
+.dropdown-menu a:hover {
+  background-color: var(--color-gray-100);
+  text-decoration: none;
+}
+
+.dropdown-divider {
+  height: 1px;
+  background-color: var(--color-gray-200);
+  margin: var(--space-2) 0;
+}
+
+/* Highlighted nav item (Pipeline) */
+.nav-highlight .nav-link {
+  background-color: rgba(37, 99, 235, 0.2);
+  color: #93c5fd;
+  font-weight: 600;
+}
+
+.nav-highlight .nav-link:hover {
+  background-color: rgba(37, 99, 235, 0.3);
+  color: #dbeafe;
+}
+
+/* External link */
+.nav-external .nav-link {
+  opacity: 0.7;
+}
+
+.nav-external .nav-link:hover {
+  opacity: 1;
 }
 
 /* ============================================
@@ -734,4 +872,129 @@ button:focus,
     border-color: var(--color-gray-700);
   }
   */
+}
+
+/* ============================================
+   Announcement Banner
+   ============================================ */
+
+.announcement-banner {
+  background: linear-gradient(135deg, var(--color-info-bg) 0%, var(--color-primary-light) 100%);
+  border-left: 4px solid var(--color-info);
+  padding: var(--space-4) var(--space-6);
+  margin-bottom: var(--space-8);
+  border-radius: var(--radius-md);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  box-shadow: var(--shadow-sm);
+}
+
+.announcement-icon {
+  font-size: var(--text-2xl);
+  flex-shrink: 0;
+}
+
+.announcement-text {
+  font-size: var(--text-base);
+  color: var(--color-gray-700);
+  line-height: 1.5;
+}
+
+.announcement-text a {
+  color: var(--color-primary);
+  font-weight: 600;
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  transition: border-color 0.2s ease;
+}
+
+.announcement-text a:hover {
+  border-bottom-color: var(--color-primary);
+}
+
+/* ============================================
+   CLI Command Reference Grid
+   ============================================ */
+
+.command-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-5);
+  margin: var(--space-6) 0 var(--space-8) 0;
+}
+
+.command-box {
+  background: linear-gradient(135deg, #ffffff 0%, #f9fafb 100%);
+  padding: var(--space-5);
+  border-radius: var(--radius-lg);
+  border: 2px solid var(--color-gray-200);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+}
+
+.command-box::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  background: linear-gradient(90deg, var(--color-primary) 0%, var(--color-primary-light) 100%);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s ease;
+}
+
+.command-box:hover {
+  border-color: var(--color-primary);
+  box-shadow: 0 8px 24px rgba(37, 99, 235, 0.12);
+  transform: translateY(-2px);
+}
+
+.command-box:hover::before {
+  transform: scaleX(1);
+}
+
+.command-box h4 {
+  margin: 0 0 var(--space-3) 0;
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--color-gray-900);
+}
+
+.command-box h4 a {
+  color: var(--color-gray-900);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.command-box h4 a:hover {
+  color: var(--color-primary);
+}
+
+.command-box p {
+  margin: 0 0 var(--space-4) 0;
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  color: var(--color-gray-600);
+}
+
+.command-box code {
+  display: block;
+  background-color: var(--color-gray-900);
+  color: #10b981;
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  margin-top: auto;
+}
+
+@media (max-width: 768px) {
+  .command-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,11 @@ layout: home
 title: Home
 ---
 
+<div class="announcement-banner">
+  <span class="announcement-icon">🚀</span>
+  <span class="announcement-text">New: <a href="release-process-visualization.html">Interactive Release Pipeline Visualization</a> - See how AgentReady's automated release process works end-to-end with real-world examples</span>
+</div>
+
 # AgentReady
 
 **Build and maintain agent-ready codebases with automated infrastructure generation and continuous quality assessment.**
@@ -12,6 +17,7 @@ title: Home
   <div class="hero-buttons">
     <a href="user-guide.html#bootstrap-your-repository" class="button button-primary">Bootstrap Your Repo</a>
     <a href="user-guide.html#running-assessments" class="button button-secondary">Run Assessment</a>
+    <a href="release-process-visualization.html" class="button button-tertiary">📊 Release Pipeline</a>
   </div>
 </div>
 
@@ -115,6 +121,81 @@ open .agentready/report-latest.html
 - Three report formats (HTML, Markdown, JSON)
 
 [Read the complete user guide →](user-guide.html)
+
+## CLI Reference
+
+AgentReady provides a comprehensive CLI with multiple commands for different workflows:
+
+```
+Usage: agentready [OPTIONS] COMMAND [ARGS]...
+
+  AgentReady Repository Scorer - Assess repositories for AI-assisted
+  development.
+
+  Evaluates repositories against 25 evidence-based attributes and generates
+  comprehensive reports with scores, findings, and remediation guidance.
+
+Options:
+  --version  Show version information
+  --help     Show this message and exit.
+
+Commands:
+  align             Align repository with best practices by applying fixes
+  assess            Assess a repository against agent-ready criteria
+  assess-batch      Assess multiple repositories in a batch operation
+  bootstrap         Bootstrap repository with GitHub infrastructure
+  demo              Run an automated demonstration of AgentReady
+  experiment        SWE-bench experiment commands
+  extract-skills    Extract reusable patterns and generate Claude Code skills
+  generate-config   Generate example configuration file
+  learn             Extract reusable patterns and generate skills (alias)
+  migrate-report    Migrate assessment report to different schema version
+  repomix-generate  Generate Repomix repository context for AI consumption
+  research          Manage and validate research reports
+  research-version  Show bundled research report version
+  submit            Submit assessment results to AgentReady leaderboard
+  validate-report   Validate assessment report against schema version
+```
+
+### Core Commands
+
+<div class="command-grid">
+  <div class="command-box">
+    <h4>🚀 <a href="user-guide.html#bootstrap-your-repository">bootstrap</a></h4>
+    <p>One-command infrastructure generation. Creates GitHub Actions, pre-commit hooks, issue/PR templates, and more.</p>
+    <code>agentready bootstrap .</code>
+  </div>
+
+  <div class="command-box">
+    <h4>🔧 <a href="user-guide.html#align-command">align</a></h4>
+    <p>Automated remediation. Applies fixes to improve your score (create CLAUDE.md, add pre-commit hooks, update .gitignore).</p>
+    <code>agentready align --dry-run .</code>
+  </div>
+
+  <div class="command-box">
+    <h4>📊 <a href="user-guide.html#running-assessments">assess</a></h4>
+    <p>Deep analysis of 25 attributes. Generates HTML, Markdown, and JSON reports with remediation guidance.</p>
+    <code>agentready assess .</code>
+  </div>
+
+  <div class="command-box">
+    <h4>🏆 <a href="leaderboard.html">submit</a></h4>
+    <p>Submit your score to the public leaderboard. Track improvements and compare with other repositories.</p>
+    <code>agentready submit</code>
+  </div>
+</div>
+
+### Specialized Commands
+
+- **`assess-batch`** - Assess multiple repositories in parallel ([batch documentation →](user-guide.html#batch-assessment))
+- **`demo`** - Interactive demonstration mode showing AgentReady in action
+- **`extract-skills`/`learn`** - Generate Claude Code skills from repository patterns
+- **`repomix-generate`** - Create AI-optimized repository context files
+- **`experiment`** - Run SWE-bench validation studies ([experiments →](developer-guide.html#experiments))
+- **`research`** - Manage research report versions and validation
+- **`migrate-report`/`validate-report`** - Schema management and migration tools
+
+[View detailed command documentation →](user-guide.html#command-reference)
 
 ## Certification Levels
 
@@ -259,16 +340,25 @@ Every attribute includes specific citations and measurable criteria. No subjecti
   </div>
 </div>
 
-## What Users Are Saying
+## What The AI Bubble Taught Us
 
-> "Running AgentReady on our codebase identified 5 quick wins that immediately improved Claude Code's suggestions. The actionable remediation made it easy to implement changes in under an hour."
-> — *Engineering Team Lead*
+> "Fired all our junior developers because 'AI can code now,' then spent $2M on GitHub Copilot Enterprise only to discover it works better with... documentation? And tests? Turns out you can't replace humans with spicy autocomplete and vibes."
+> — *CTO, Currently Rehiring*
 
-> "The research backing each attribute gave me confidence these weren't arbitrary rules. Every recommendation is cited and measurable."
-> — *Principal Engineer*
+> "My AI coding assistant told me it was 'very confident' about a solution that would have deleted production. Running AgentReady revealed our codebase has the readability of a ransom note. The AI was confident because it had no idea what it was doing. Just like us!"
+> — *Senior Developer, Trust Issues Intensifying*
 
-> "We use AgentReady in CI to prevent regression. It's become part of our definition of done for new features."
-> — *DevOps Engineer*
+> "We added 'AI-driven development' to the Series B deck before checking if our monolith had a README. AgentReady scored us 23/100. The AI couldn't figure out our codebase because *we* couldn't figure out our codebase. Investors were not impressed."
+> — *VP Engineering, Learning About README Files The Hard Way*
+
+> "Spent the year at conferences saying 'AI will 10x productivity' while our agents hallucinated imports, invented APIs, and confidently suggested `rm -rf /`. AgentReady showed us we're missing pre-commit hooks, type annotations, and basic self-awareness. The only thing getting 10x'd was our incident rate."
+> — *Tech Lead, Reformed Hype Man*
+
+> "Asked ChatGPT to refactor our auth system. It wrote beautiful code that compiled perfectly and had zero relation to our actual database schema. Turns out when you have no CLAUDE.md file, no ADRs, and variable names like `data2_final_FINAL`, even AGI would just be guessing. And AGI doesn't exist yet."
+> — *Staff Engineer, Back to Documentation Basics*
+
+> "My manager saw a demo where AI 'wrote an entire app' and asked why I'm still employed. I showed him our AgentReady score of 31/100, explained that missing lock files and zero test coverage make AI as useful as a Magic 8-Ball, and we spent the next quarter actually engineering instead of prompt-debugging. AI didn't replace me. Basic hygiene saved me."
+> — *Developer, Still Employed, Surprisingly*
 
 ## Ready to Get Started?
 


### PR DESCRIPTION
## Summary

Updates GitHub Pages documentation with CLI reference section and refreshed AI hype cycle commentary.

## Changes

### CLI Reference Section
- Add full CLI help output showing all 15+ commands  
- Create interactive command grid highlighting core commands (bootstrap, align, assess, submit)
- Add styled command boxes with hover effects and terminal-style code blocks
- Link each command to detailed documentation

### AI Bubble Snark  
- Replace old quotes with sharper satire on current AI hysteria
- Focus on gap between LLM promises and engineering reality
- Themes: "spicy autocomplete", hallucinated code, Series B decks vs actual quality, job security through hygiene

### CSS Additions
- .command-grid responsive layout
- .command-box with gradient backgrounds and hover animations  
- Terminal-style code blocks (green on dark)
- Mobile-responsive (4 columns → 1 on narrow screens)

## Testing
- ✅ All markdown linting passes
- ✅ Links validated
- ✅ Pre-commit hooks pass

## Preview
Changes affect only documentation display, no functionality changes.

Co-authored-by: Claude <noreply@anthropic.com>