### PR TITLE
fix: skip PR comments for external forks to prevent permission errors

### DIFF
--- a/.github/workflows/agentready-assessment.yml
+++ b/.github/workflows/agentready-assessment.yml
@@ -40,7 +40,7 @@ jobs:
           retention-days: 30
 
       - name: Comment on PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary

Fixes the workflow failure `HttpError: Resource not accessible by integration` when the agentready-assessment workflow runs on pull requests from external repositories (forks).

## Problem

When workflows run on PRs from forks, GitHub automatically restricts the `GITHUB_TOKEN`'s write permissions for security. This caused the "Comment on PR" step to fail with a permission error, preventing assessment reports from being uploaded.

## Solution

Added fork detection to the PR comment conditional:
```yaml
if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
```

## Impact

**Before**: 
- ✅ Same-repo PRs → comments successfully  
- ❌ Fork PRs → crashes with permission error
- ❌ No assessment reports uploaded

**After**:
- ✅ Same-repo PRs → comments successfully
- ✅ Fork PRs → skips comment, uploads artifacts successfully  
- ✅ Assessment runs in both cases

## Testing

- [ ] Verify PR comment appears on same-repo PRs
- [ ] Verify workflow succeeds on fork PRs without commenting
- [ ] Verify assessment reports upload in both scenarios

## References

- Workflow run that failed: https://github.com/ambient-code/agentready/actions/runs/19936237947/job/57175715505
- This is the industry-standard approach for handling fork PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)