### PR TITLE
fix: add bounded retry logic for LLM rate limit handling

### DIFF
--- a/src/agentready/cli/learn.py
+++ b/src/agentready/cli/learn.py
@@ -58,6 +58,12 @@ from ..services.learning_service import LearningService
     is_flag=True,
     help="Bypass LLM response cache (always call API)",
 )
+@click.option(
+    "--llm-max-retries",
+    type=click.IntRange(min=0, max=10),
+    default=3,
+    help="Maximum retry attempts for LLM rate limits (default: 3)",
+)
 def learn(
     repository,
     output_format,
@@ -68,6 +74,7 @@ def learn(
     enable_llm,
     llm_budget,
     llm_no_cache,
+    llm_max_retries,
 ):
     """Extract reusable patterns and generate Claude Code skills.
 
@@ -172,6 +179,7 @@ def learn(
             attribute_ids=list(attribute) if attribute else None,
             enable_llm=enable_llm,
             llm_budget=llm_budget,
+            llm_max_retries=llm_max_retries,
         )
     except Exception as e:
         click.echo(f"\nError during learning: {str(e)}", err=True)


### PR DESCRIPTION
## Summary
- Add max_retries parameter to prevent infinite retry loops when API rate limits are hit
- Add configurable timeout for LLM enrichment operations
- Add graceful fallback with helpful error messages

## Changes
- Add `max_retries` parameter (default: 3) to `LLMEnricher.enrich_skill()`
- Add retry counter tracking with `_retry_count` internal parameter
- Implement jitter to prevent thundering herd problem
- Add graceful fallback to heuristic skill on max retries exceeded
- Add `--llm-max-retries` CLI option (range: 0-10, default: 3)
- Thread parameter through `learning_service.py` workflow

## Security Improvements
- Bounded retries prevent runaway API costs
- Helpful error messages with API quota link
- Graceful degradation when retries exhausted

## Test Plan
- [x] All linters pass (black, isort, ruff)
- [x] Pre-commit hooks pass
- [x] Conventional commit format verified
- [ ] Manual test with simulated rate limits (requires API key)

Fixes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>