### PR TITLE
fix: update --version flag to show correct version and research report date

### DIFF
--- a/src/agentready/cli/main.py
+++ b/src/agentready/cli/main.py
@@ -561,8 +561,15 @@ cli.add_command(validate_report)
 def show_version():
     """Show version information."""
     version = get_agentready_version()
-    click.echo(f"AgentReady Repository Scorer v{version}")
-    click.echo("Research Report: bundled")
+    click.echo(f"AgentReady v{version}")
+
+    # Load research report date
+    try:
+        loader = ResearchLoader()
+        _, metadata, _, _, _ = loader.load_and_validate()
+        click.echo(f"Research Report: {metadata.date}")
+    except Exception:
+        click.echo("Research Report: unknown")
 
 
 if __name__ == "__main__":

--- a/src/agentready/services/research_loader.py
+++ b/src/agentready/services/research_loader.py
@@ -65,7 +65,7 @@ class ResearchLoader:
         Raises:
             ValueError: If metadata cannot be extracted
         """
-        # Extract version and date from YAML frontmatter
+        # Try to extract version and date from YAML frontmatter first
         frontmatter_match = re.search(
             r"^---\s*\nversion:\s*([^\n]+)\s*\ndate:\s*([^\n]+)\s*\n---",
             content,
@@ -76,9 +76,12 @@ class ResearchLoader:
             version = frontmatter_match.group(1).strip()
             date = frontmatter_match.group(2).strip()
         else:
-            # Default version if not found
-            version = "1.0.0"
-            date = "unknown"
+            # Fallback: Try Markdown bold format (**Version:** 1.0.1)
+            version_match = re.search(r"\*\*Version:\*\*\s+([^\n]+)", content)
+            date_match = re.search(r"\*\*Date:\*\*\s+([^\n]+)", content)
+
+            version = version_match.group(1).strip() if version_match else "1.0.0"
+            date = date_match.group(1).strip() if date_match else "unknown"
 
         # Count attributes (look for ### headings with numbering like "1.1", "2.3", etc.)
         attribute_pattern = r"^###\s+\d+\.\d+\s+"


### PR DESCRIPTION
## Summary
- Remove "Repository Scorer" from version output
- Display actual research report date instead of "bundled"
- Version now correctly reflects package metadata from pyproject.toml

## Changes
- Updated `show_version()` in `src/agentready/cli/main.py` to display clean version format
- Enhanced `ResearchLoader` in `src/agentready/services/research_loader.py` to parse both YAML frontmatter and Markdown bold format for metadata extraction

## Test Plan
- [x] Linting: `black`, `isort`, `ruff` all passed
- [x] Tests: All 41 research-related tests passed
- [x] Manual verification: `agentready --version` shows correct output

## Before
```
AgentReady Repository Scorer v2.15.0
Research Report: bundled
```

## After
```
AgentReady v2.20.1
Research Report: 2025-12-08
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)