### PR TITLE
fix: downgrade docker/metadata-action to v5 and fix shellcheck warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/ambient-code/agentready
           tags: |
@@ -143,19 +143,21 @@ jobs:
           VERSION: ${{ needs.release.outputs.version }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          echo "## Container Published to GHCR" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "📦 **Version**: $VERSION" >> $GITHUB_STEP_SUMMARY
-          echo "🐳 **Registry**: ghcr.io/$REPOSITORY" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Usage" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "# Pull latest" >> $GITHUB_STEP_SUMMARY
-          echo "podman pull ghcr.io/$REPOSITORY:latest" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "# Pull specific version" >> $GITHUB_STEP_SUMMARY
-          echo "podman pull ghcr.io/$REPOSITORY:$VERSION" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "# Run assessment" >> $GITHUB_STEP_SUMMARY
-          echo "podman run --rm -v /path/to/repo:/repo:ro ghcr.io/$REPOSITORY:latest assess /repo --output-dir /tmp/out" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Container Published to GHCR"
+            echo ""
+            echo "📦 **Version**: $VERSION"
+            echo "🐳 **Registry**: ghcr.io/$REPOSITORY"
+            echo ""
+            echo "### Usage"
+            echo "\`\`\`bash"
+            echo "# Pull latest"
+            echo "podman pull ghcr.io/$REPOSITORY:latest"
+            echo ""
+            echo "# Pull specific version"
+            echo "podman pull ghcr.io/$REPOSITORY:$VERSION"
+            echo ""
+            echo "# Run assessment"
+            echo "podman run --rm -v /path/to/repo:/repo:ro ghcr.io/$REPOSITORY:latest assess /repo --output-dir /tmp/out"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Downgrade `docker/metadata-action` from v6 to v5 (v6 tag doesn't exist yet)
- Fix shellcheck SC2086 warnings by quoting `$GITHUB_STEP_SUMMARY`
- Fix shellcheck SC2129 by using grouped redirects

## Problem
The v2.21.0 release succeeded in publishing to PyPI, but the container build job failed with:
```
Unable to resolve action docker/metadata-action@v6, unable to find version v6
```

## Solution
According to the [docker/metadata-action releases](https://github.com/docker/metadata-action/releases), the latest stable version is v5.7.0. The v6 tag referenced in the workflow doesn't exist yet.

This PR downgrades to `docker/metadata-action@v5` which is the current stable major version.

## Additional Improvements
- Fixed all shellcheck warnings in the container summary step
- Used grouped redirects for cleaner shell code
- Properly quoted environment variables to prevent globbing

## Test Plan
- [x] Workflow passes actionlint validation locally
- [x] Pre-commit hooks pass (including actionlint)
- [ ] Verify container build succeeds in CI after merge

## References
- [docker/metadata-action releases](https://github.com/docker/metadata-action/releases)
- Failed workflow: https://github.com/ambient-code/agentready/actions/runs/20245124709

🤖 Generated with [Claude Code](https://claude.com/claude-code)