### PR TITLE
fix(ci): use gh pr view for fork PR number lookup in coverage comment

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -24,26 +24,42 @@ jobs:
     steps:
       - name: Get PR number from workflow run
         id: pr_info
-        uses: actions/github-script@v7
-        with:
-          script: |
-            // Get the PR associated with the workflow run (trusted source)
-            const workflowRun = await github.rest.actions.getWorkflowRun({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.payload.workflow_run.id
-            });
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # For fork PRs, pull_requests array is empty in workflow_run event
+          # Use gh pr view to find the PR number
+          # See: https://github.com/orgs/community/discussions/25220
 
-            // Extract PR number from the workflow run's pull_requests array
-            const pullRequests = workflowRun.data.pull_requests;
-            if (!pullRequests || pullRequests.length === 0) {
-              core.setFailed('No pull request associated with this workflow run');
-              return;
-            }
+          HEAD_REPO="${{ github.event.workflow_run.head_repository.full_name }}"
+          HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
+          TARGET_REPO="${{ github.repository }}"
 
-            const prNumber = pullRequests[0].number;
-            core.setOutput('pr_number', prNumber);
-            console.log(`PR number from workflow run: ${prNumber}`);
+          echo "Looking for PR from ${HEAD_REPO} branch ${HEAD_BRANCH}"
+
+          # Determine branch query format:
+          # - Fork PRs: use "owner:branch" format
+          # - Same-repo PRs: use just "branch" format
+          if [ "$HEAD_REPO" = "$TARGET_REPO" ]; then
+            BRANCH_QUERY="${HEAD_BRANCH}"
+          else
+            BRANCH_QUERY="${HEAD_REPO%%/*}:${HEAD_BRANCH}"
+          fi
+
+          echo "Using branch query: ${BRANCH_QUERY}"
+
+          PR_NUMBER=$(gh pr view \
+            --repo "$TARGET_REPO" \
+            "$BRANCH_QUERY" \
+            --json number --jq .number 2>/dev/null || echo "")
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::Could not find PR for ${BRANCH_QUERY} in ${TARGET_REPO}"
+            exit 1
+          fi
+
+          echo "Found PR #${PR_NUMBER}"
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
       - name: Download coverage data
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Description

The workflow_run event's pull_requests array is empty for fork PRs due to a known GitHub limitation. This prevented coverage comments from being posted on fork PRs.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues

Relates to https://github.com/orgs/community/discussions/25220

## Changes Made

Replace the JavaScript-based pull_requests array lookup with gh pr view command, which reliably finds PRs from both forks and the same repo. Add conditional logic to use the correct branch query format:
- Fork PRs: "owner:branch" format
- Same-repo PRs: "branch" format

## Testing

- Fork PR query: gh pr view "chambridge:fix/245-..." --repo ambient-code/agentready → returned PR #248
- Same-repo PR query: gh pr view "automated/research-update" --repo ambient-code/agentready → returned PR #243
- actionlint validation: Passed with no errors

- [ ] Unit tests pass (`pytest`)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] No new warnings or errors

## Checklist

- [ ] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
