### PR TITLE
fix: prevent unauthorized message for non-command comments

### DIFF
--- a/.github/workflows/agentready-assessment.yml
+++ b/.github/workflows/agentready-assessment.yml
@@ -17,6 +17,7 @@ jobs:
     
     outputs:
       is_authorized: ${{ steps.check-agentready-acl.outputs.is_authorized }}
+      command_invoked: ${{ steps.check-agentready-acl.outputs.command_invoked }}
     
     steps:
       - name: Checkout repository
@@ -44,9 +45,12 @@ jobs:
           
           # Check if comment contains the command
           if ! echo "$COMMENT_BODY" | grep -qi "/agentready assess"; then
+            echo "command_invoked=false" >> "$GITHUB_OUTPUT"
             echo "is_authorized=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          
+          echo "command_invoked=true" >> "$GITHUB_OUTPUT"
           
           # Read ACL file and check if user is authorized
           if [ ! -f ".github/agentready-acl.yml" ]; then
@@ -72,6 +76,7 @@ jobs:
     # Respond to unauthorized users with helpful message
     needs: check-agentready-acl
     if: |
+      needs.check-agentready-acl.outputs.command_invoked == 'true' &&
       needs.check-agentready-acl.outputs.is_authorized == 'false' &&
       (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment')
 


### PR DESCRIPTION
## Description

The unauthorized job was incorrectly triggered for any comment from ACL-listed users that didn't contain '/agentready assess'. This fix adds a 'command_invoked' output to distinguish between:
- Command not present in comment (do nothing)
- Command present but user unauthorized (show message)

The unauthorized job now only runs when command_invoked=true AND is_authorized=false.
## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues

#249

## Changes Made

#### .github/workflows/agentready-assessment.yml

 1. Added new output to job
```
outputs:
  is_authorized: ${{ steps.check-agentready-acl.outputs.is_authorized }}
+ command_invoked: ${{ steps.check-agentready-acl.outputs.command_invoked }}
```
 2. Set command_invoked flag in script
```
if ! echo "$COMMENT_BODY" | grep -qi "/agentready assess"; then
+ echo "command_invoked=false" >> "$GITHUB_OUTPUT"
  echo "is_authorized=false" >> "$GITHUB_OUTPUT"
  exit 0
fi
+ echo "command_invoked=true" >> "$GITHUB_OUTPUT"
```
 3. Updated unauthorized job condition

```
if: |
+ needs.check-agentready-acl.outputs.command_invoked == 'true' &&
  needs.check-agentready-acl.outputs.is_authorized == 'false' &&
  (github.event_name == 'issue_comment' || ...)
```

## Testing

Test Issue with test comments : 
https://github.com/kami619/agentready/issues/4

Working Runs:
- https://github.com/kami619/agentready/actions/runs/21044358399 - With the user in the ACL list `/agentready assess` works without issue.
- https://github.com/kami619/agentready/actions/runs/21044323795 - With the user not in the ACL `/agentready assess` action skips from being executed.
- https://github.com/kami619/agentready/actions/runs/21044302298 - With the comment body not containing `/agentready assess` the action skips from executed the ACL checks.


- [ ] Unit tests pass (`pytest`)
- [ ] Integration tests pass
- [X] Manual testing performed
- [ ] No new warnings or errors



## Checklist

- [X] My code follows the project's code style
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published