### PR TITLE
Feature/claude init claude md

### DIFF
--- a/src/agentready/models/fix.py
+++ b/src/agentready/models/fix.py
@@ -133,11 +133,13 @@ class CommandFix(Fix):
         command: Command to execute
         working_dir: Directory to run command in
         repository_path: Repository root path
+        capture_output: If True, suppress stdout/stderr; if False, stream to terminal
     """
 
     command: str
     working_dir: Optional[Path]
     repository_path: Path
+    capture_output: bool = True
 
     def apply(self, dry_run: bool = False) -> bool:
         """Execute the command.
@@ -166,7 +168,7 @@ class CommandFix(Fix):
                 cmd_list,
                 cwd=cwd,
                 check=True,
-                capture_output=True,
+                capture_output=self.capture_output,
                 text=True,
                 # Security: Never use shell=True - explicitly removed
             )


### PR DESCRIPTION
## Description

Replace static Jinja2 template-based CLAUDE.md generation with dynamic Claude CLI invocation, enabling repo-aware CLAUDE.md files that understand project context. Added prerequisite checks for Claude CLI availability and ANTHROPIC_API_KEY, progress logging during fix application, and comprehensive test coverage.


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues



Fixes #272  


## Changes Made


- CLAUDEmdFixer: Now runs claude -p "Initialize this project with a CLAUDE.md file" instead of rendering a static template
Prerequisite checks: Fix is only offered when claude CLI is on PATH and ANTHROPIC_API_KEY is set
- CommandFix.capture_output: New parameter (default True) to control whether subprocess output is captured or streamed to terminal
- FixerService.apply_fixes(): Added optional progress_callback(fix, phase, success) for before/after logging
- Align CLI tip: Shows helpful message when CLAUDE.md fix is skipped due to missing CLI/key
- Align CLI logging: Echoes "Generating CLAUDE.md file..." when applying the fix
- Test coverage: Added / Updated tests covering all new behavior

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [X] Unit tests pass (`pytest`)
- [ ] Integration tests pass
- [X] Manual testing performed
- [ ] No new warnings or errors

## Checklist

- [X] My code follows the project's code style
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [  ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
