### PR TITLE
fix: Use removesuffix instead of rstrip for .git URL stripping

### DIFF
--- a/src/agentready/cli/submit.py
+++ b/src/agentready/cli/submit.py
@@ -68,10 +68,10 @@ def extract_repo_info(assessment_data: dict) -> tuple[str, str, float, str]:
     try:
         # Handle SSH format: git@github.com:org/repo.git
         if repo_url.startswith("git@github.com:"):
-            org_repo = repo_url.split("git@github.com:")[1].rstrip(".git")
+            org_repo = repo_url.split("git@github.com:")[1].removesuffix(".git")
         # Handle HTTPS format: https://github.com/org/repo.git
         else:
-            org_repo = repo_url.split("github.com/")[1].strip("/").rstrip(".git")
+            org_repo = repo_url.split("github.com/")[1].strip("/").removesuffix(".git")
 
         org, repo = org_repo.split("/")
     except (IndexError, ValueError):

--- a/src/agentready/services/repository_manager.py
+++ b/src/agentready/services/repository_manager.py
@@ -93,7 +93,7 @@ class RepositoryManager:
         # For URLs, extract from the last part of the path
         # https://github.com/user/repo.git -> repo
         parsed = urlparse(url)
-        path = parsed.path.rstrip("/").rstrip(".git")
+        path = parsed.path.rstrip("/").removesuffix(".git")
         return Path(path).name or "repository"
 
     def clone_repository(

--- a/tests/unit/test_cli_submit.py
+++ b/tests/unit/test_cli_submit.py
@@ -1,0 +1,91 @@
+"""Unit tests for CLI submit command."""
+
+from agentready.cli.submit import extract_repo_info
+
+
+class TestExtractRepoInfo:
+    """Test extract_repo_info function."""
+
+    def test_extract_repo_info_https_with_git_suffix(self):
+        """Test extract_repo_info handles HTTPS .git suffix correctly."""
+        assessment_data = {
+            "repository": {"url": "https://github.com/feast-dev/feast.git"},
+            "overall_score": 85.0,
+            "certification_level": "Gold",
+        }
+
+        org, repo, score, tier = extract_repo_info(assessment_data)
+        assert org == "feast-dev"
+        assert repo == "feast"  # Not "feas"
+        assert score == 85.0
+        assert tier == "Gold"
+
+    def test_extract_repo_info_https_without_git_suffix(self):
+        """Test extract_repo_info handles HTTPS URL without .git suffix."""
+        assessment_data = {
+            "repository": {"url": "https://github.com/org/my-repo"},
+            "overall_score": 70.0,
+            "certification_level": "Silver",
+        }
+
+        org, repo, score, tier = extract_repo_info(assessment_data)
+        assert org == "org"
+        assert repo == "my-repo"
+
+    def test_extract_repo_info_ssh_with_git_suffix(self):
+        """Test extract_repo_info handles SSH .git suffix correctly."""
+        assessment_data = {
+            "repository": {"url": "git@github.com:feast-dev/feast.git"},
+            "overall_score": 60.5,
+            "certification_level": "Silver",
+        }
+
+        org, repo, score, tier = extract_repo_info(assessment_data)
+        assert org == "feast-dev"
+        assert repo == "feast"  # Not "feas"
+        assert score == 60.5
+        assert tier == "Silver"
+
+    def test_extract_repo_info_ssh_without_git_suffix(self):
+        """Test extract_repo_info handles SSH URL without .git suffix."""
+        assessment_data = {
+            "repository": {"url": "git@github.com:org/my-repo"},
+            "overall_score": 90.0,
+            "certification_level": "Gold",
+        }
+
+        org, repo, score, tier = extract_repo_info(assessment_data)
+        assert org == "org"
+        assert repo == "my-repo"
+
+    def test_extract_repo_info_preserves_names_ending_in_git_chars(self):
+        """Regression test: repo names ending in .git characters are preserved.
+
+        rstrip('.git') incorrectly strips individual characters (., g, i, t)
+        from the end of names. removesuffix('.git') is correct.
+        """
+        test_cases = [
+            ("feast-dev/feast.git", "feast-dev", "feast"),  # Not "feas"
+            ("user/audit.git", "user", "audit"),  # Not "aud"
+            ("user/digit.git", "user", "digit"),  # Not "di"
+            ("org/widget.git", "org", "widget"),  # Not "widge"
+        ]
+
+        for url_suffix, expected_org, expected_repo in test_cases:
+            for url_template in [
+                f"https://github.com/{url_suffix}",
+                f"git@github.com:{url_suffix}",
+            ]:
+                assessment_data = {
+                    "repository": {"url": url_template},
+                    "overall_score": 80.0,
+                    "certification_level": "Gold",
+                }
+
+                org, repo, score, tier = extract_repo_info(assessment_data)
+                assert (
+                    org == expected_org
+                ), f"Expected org '{expected_org}' but got '{org}' for URL: {url_template}"
+                assert (
+                    repo == expected_repo
+                ), f"Expected repo '{expected_repo}' but got '{repo}' for URL: {url_template}"


### PR DESCRIPTION
## Description

This PR fixes repository name parsing bug where `rstrip(".git")` was incorrectly stripping individual characters (`.`, `g`, `i`, `t`) from the end of repo names instead of removing the literal `.git` suffix. This caused repos like `feast-dev/feast` to be truncated to `feast-dev/feas`.

Python's `str.rstrip(chars)` treats its argument as a **set of characters** to strip,
not a literal string. So `.rstrip(".git")` strips any trailing combination of `.`, `g`,
`i`, and `t` — silently corrupting repository names that end in those characters
(e.g., `feast` → `feas`, `audit` → `aud`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues

<!-- Link related issues here using #issue_number -->

Fixes #
Relates to #

## Changes Made

- `src/agentready/cli/submit.py` — `extract_repo_info()` (lines 71, 74)
- `src/agentready/services/repository_manager.py` — `get_repository_name_from_url()` (line 96)

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass (`pytest`)
- [x] Integration tests pass
- [x] Manual testing performed
- [x] No new warnings or errors

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

