### PR TITLE
Is 295 org repo extraction fix

### DIFF
--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -106,7 +106,7 @@ jobs:
           SUBMITTER: ${{ github.event.pull_request.user.login }}
         run: |
           # SAFE: All values in environment variables
-          ORG_REPO=$(echo "$REPO_URL" | sed 's|https://github.com/||' | sed 's|\.git$||')
+          ORG_REPO=$(echo "$REPO_URL" | sed 's|git@github.com:||' | sed 's|https://github.com/||' | sed 's|\.git$||')
 
           if gh api "/repos/$ORG_REPO/collaborators/$SUBMITTER" 2>/dev/null; then
             echo "✅ $SUBMITTER is a collaborator on $ORG_REPO"


### PR DESCRIPTION
## Description

ORG_REPO extraction only stripped https://github.com/ prefixes, fixing it to support all different git urls.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues

Fixes #295

## Changes Made

SSH URL parsing — The ORG_REPO extraction (used in both "Verify repository exists" and "Verify submitter has access" steps) needs to handle git@github.com:org/repo.git in addition to https://github.com/org/repo.git. Replace the sed line in both steps:          
                                                                                                                                                                                                                                                              
  # Before (only handles HTTPS)                                                                                                                                                                                                                               
  ORG_REPO=$(echo "$REPO_URL" | sed 's|https://github.com/||' | sed 's|\.git$||')

  # After (handles both SSH and HTTPS)
  ORG_REPO=$(echo "$REPO_URL" | sed 's|git@github.com:||' | sed 's|https://github.com/||' | sed 's|\.git$||')

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] No new warnings or errors

## Checklist

- [X] My code follows the project's code style
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published