### PR TITLE
fix: Use GitHub URL instead of local one

### DIFF
--- a/scripts/generate-leaderboard-data.py
+++ b/scripts/generate-leaderboard-data.py
@@ -95,7 +95,7 @@ def generate_leaderboard_data(repos: dict[str, list[dict[str, Any]]]) -> dict[st
                 "language": latest["repository"].get("primary_language", "Unknown"),
                 "size": latest["repository"].get("size_category", "Unknown"),
                 "last_updated": submissions[0]["timestamp"][:10],  # YYYY-MM-DD
-                "url": latest["repository"]["url"],
+                "url": f"https://github.com/{repo_name}",
                 "agentready_version": agentready_version,
                 "research_version": research_version,
                 "history": [


### PR DESCRIPTION
When the assessment is generated, it adds the URL configured in the user's local copy of the repo, which can be an SSH URL. This then gets rendered as is in the leaderboard, causing broken URLs.

Since submissions can only be created for GitHub URLs, add an explicit URL using https in the generated leaderboard.

## Description

When the assessment is generated, it adds the URL configured in the user's local copy of the repo, which can be an SSH URL. This then gets rendered as is in the leaderboard, causing broken URLs.

Since submissions can only be created for GitHub URLs, add an explicit URL using https in the generated leaderboard.

This fixes the currently broken links in the top 10 view at https://ambient-code.github.io/agentready/.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Update to leaderboard generator script

## Testing

Ran the leaderboard generation script and it correctly fixed the URLs:

```
@@ -42,7 +42,7 @@
       "language": "Unknown",
       "size": "Unknown",
       "last_updated": "2026-02-17",
-      "url": "git@github.com:opendatahub-io/ai-helpers.git",
+      "url": "https://github.com/opendatahub-io/ai-helpers",
       "agentready_version": "2.27.3",
       "research_version": "1.0.1",
       "history": [
```


