### PR TITLE
fix: Enable workflow_dispatch for leaderboard update and regenerate data

### DIFF
--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -11,6 +11,7 @@ on:
     branches: [main]
     paths:
       - 'submissions/**/*-assessment.json'
+      - 'scripts/generate-leaderboard-data.py'
 
   # Manual trigger for testing
   workflow_dispatch:
@@ -181,9 +182,9 @@ jobs:
               body: body
             });
 
-  # Job 2: Update leaderboard data (after merge to main)
+  # Job 2: Update leaderboard data (after merge to main, or manual trigger)
   update:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: write           # Commit and push updated leaderboard data

--- a/docs/_data/leaderboard.json
+++ b/docs/_data/leaderboard.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-02-17T22:07:33.795485Z",
+  "generated_at": "2026-02-18T15:41:53.494737Z",
   "total_repositories": 9,
   "overall": [
     {
@@ -42,7 +42,7 @@
       "language": "Unknown",
       "size": "Unknown",
       "last_updated": "2026-02-17",
-      "url": "git@github.com:opendatahub-io/ai-helpers.git",
+      "url": "https://github.com/opendatahub-io/ai-helpers",
       "agentready_version": "2.27.3",
       "research_version": "1.0.1",
       "history": [
@@ -73,7 +73,7 @@
       "language": "Unknown",
       "size": "Unknown",
       "last_updated": "2026-02-06",
-      "url": "https://github.com/python-wheel-build/fromager.git",
+      "url": "https://github.com/python-wheel-build/fromager",
       "agentready_version": "2.25.0",
       "research_version": "1.0.1",
       "history": [
@@ -98,7 +98,7 @@
       "language": "Unknown",
       "size": "Unknown",
       "last_updated": "2026-02-07",
-      "url": "git@github.com:Red-Hat-AI-Innovation-Team/sdg_hub.git",
+      "url": "https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub",
       "agentready_version": "2.25.2",
       "research_version": "1.0.1",
       "history": [
@@ -123,7 +123,7 @@
       "language": "Unknown",
       "size": "Unknown",
       "last_updated": "2026-02-17",
-      "url": "git@github.com:feast-dev/feast.git",
+      "url": "https://github.com/feast-dev/feast",
       "agentready_version": "2.27.3",
       "research_version": "1.0.1",
       "history": [
@@ -137,31 +137,6 @@
       "rank": 5,
       "lang_rank": {
         "Unknown": 5
-      }
-    },
-    {
-      "repo": "jeremyeder/reference",
-      "org": "jeremyeder",
-      "name": "reference",
-      "score": 55.8,
-      "tier": "Bronze",
-      "language": "Unknown",
-      "size": "Unknown",
-      "last_updated": "2026-01-15",
-      "url": "https://github.com/jeremyeder/reference",
-      "agentready_version": "2.22.0",
-      "research_version": "1.0.1",
-      "history": [
-        {
-          "date": "2026-01-15",
-          "score": 55.8,
-          "agentready_version": "2.22.0",
-          "research_version": "1.0.1"
-        }
-      ],
-      "rank": 6,
-      "lang_rank": {
-        "Unknown": 6
       }
     },
     {
@@ -184,6 +159,31 @@
           "research_version": "1.0.1"
         }
       ],
+      "rank": 6,
+      "lang_rank": {
+        "Unknown": 6
+      }
+    },
+    {
+      "repo": "jeremyeder/reference",
+      "org": "jeremyeder",
+      "name": "reference",
+      "score": 55.8,
+      "tier": "Bronze",
+      "language": "Unknown",
+      "size": "Unknown",
+      "last_updated": "2026-01-15",
+      "url": "https://github.com/jeremyeder/reference",
+      "agentready_version": "2.22.0",
+      "research_version": "1.0.1",
+      "history": [
+        {
+          "date": "2026-01-15",
+          "score": 55.8,
+          "agentready_version": "2.22.0",
+          "research_version": "1.0.1"
+        }
+      ],
       "rank": 7,
       "lang_rank": {
         "Unknown": 7
@@ -198,7 +198,7 @@
       "language": "Unknown",
       "size": "Unknown",
       "last_updated": "2025-12-04",
-      "url": "git@github.com:quay/quay.git",
+      "url": "https://github.com/quay/quay",
       "agentready_version": "2.12.2",
       "research_version": "1.0.0",
       "history": [
@@ -223,7 +223,7 @@
       "language": "Unknown",
       "size": "Unknown",
       "last_updated": "2026-01-28",
-      "url": "git@github.com:dgutride/odh-dashboard.git",
+      "url": "https://github.com/dgutride/odh-dashboard",
       "agentready_version": "2.23.0",
       "research_version": "1.0.1",
       "history": [
@@ -282,7 +282,7 @@
         "language": "Unknown",
         "size": "Unknown",
         "last_updated": "2026-02-17",
-        "url": "git@github.com:opendatahub-io/ai-helpers.git",
+        "url": "https://github.com/opendatahub-io/ai-helpers",
         "agentready_version": "2.27.3",
         "research_version": "1.0.1",
         "history": [
@@ -313,7 +313,7 @@
         "language": "Unknown",
         "size": "Unknown",
         "last_updated": "2026-02-06",
-        "url": "https://github.com/python-wheel-build/fromager.git",
+        "url": "https://github.com/python-wheel-build/fromager",
         "agentready_version": "2.25.0",
         "research_version": "1.0.1",
         "history": [
@@ -338,7 +338,7 @@
         "language": "Unknown",
         "size": "Unknown",
         "last_updated": "2026-02-07",
-        "url": "git@github.com:Red-Hat-AI-Innovation-Team/sdg_hub.git",
+        "url": "https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub",
         "agentready_version": "2.25.2",
         "research_version": "1.0.1",
         "history": [
@@ -363,7 +363,7 @@
         "language": "Unknown",
         "size": "Unknown",
         "last_updated": "2026-02-17",
-        "url": "git@github.com:feast-dev/feast.git",
+        "url": "https://github.com/feast-dev/feast",
         "agentready_version": "2.27.3",
         "research_version": "1.0.1",
         "history": [
@@ -377,31 +377,6 @@
         "rank": 5,
         "lang_rank": {
           "Unknown": 5
-        }
-      },
-      {
-        "repo": "jeremyeder/reference",
-        "org": "jeremyeder",
-        "name": "reference",
-        "score": 55.8,
-        "tier": "Bronze",
-        "language": "Unknown",
-        "size": "Unknown",
-        "last_updated": "2026-01-15",
-        "url": "https://github.com/jeremyeder/reference",
-        "agentready_version": "2.22.0",
-        "research_version": "1.0.1",
-        "history": [
-          {
-            "date": "2026-01-15",
-            "score": 55.8,
-            "agentready_version": "2.22.0",
-            "research_version": "1.0.1"
-          }
-        ],
-        "rank": 6,
-        "lang_rank": {
-          "Unknown": 6
         }
       },
       {
@@ -424,6 +399,31 @@
             "research_version": "1.0.1"
           }
         ],
+        "rank": 6,
+        "lang_rank": {
+          "Unknown": 6
+        }
+      },
+      {
+        "repo": "jeremyeder/reference",
+        "org": "jeremyeder",
+        "name": "reference",
+        "score": 55.8,
+        "tier": "Bronze",
+        "language": "Unknown",
+        "size": "Unknown",
+        "last_updated": "2026-01-15",
+        "url": "https://github.com/jeremyeder/reference",
+        "agentready_version": "2.22.0",
+        "research_version": "1.0.1",
+        "history": [
+          {
+            "date": "2026-01-15",
+            "score": 55.8,
+            "agentready_version": "2.22.0",
+            "research_version": "1.0.1"
+          }
+        ],
         "rank": 7,
         "lang_rank": {
           "Unknown": 7
@@ -438,7 +438,7 @@
         "language": "Unknown",
         "size": "Unknown",
         "last_updated": "2025-12-04",
-        "url": "git@github.com:quay/quay.git",
+        "url": "https://github.com/quay/quay",
         "agentready_version": "2.12.2",
         "research_version": "1.0.0",
         "history": [
@@ -463,7 +463,7 @@
         "language": "Unknown",
         "size": "Unknown",
         "last_updated": "2026-01-28",
-        "url": "git@github.com:dgutride/odh-dashboard.git",
+        "url": "https://github.com/dgutride/odh-dashboard",
         "agentready_version": "2.23.0",
         "research_version": "1.0.1",
         "history": [
@@ -523,7 +523,7 @@
         "language": "Unknown",
         "size": "Unknown",
         "last_updated": "2026-02-17",
-        "url": "git@github.com:opendatahub-io/ai-helpers.git",
+        "url": "https://github.com/opendatahub-io/ai-helpers",
         "agentready_version": "2.27.3",
         "research_version": "1.0.1",
         "history": [
@@ -554,7 +554,7 @@
         "language": "Unknown",
         "size": "Unknown",
         "last_updated": "2026-02-06",
-        "url": "https://github.com/python-wheel-build/fromager.git",
+        "url": "https://github.com/python-wheel-build/fromager",
         "agentready_version": "2.25.0",
         "research_version": "1.0.1",
         "history": [
@@ -579,7 +579,7 @@
         "language": "Unknown",
         "size": "Unknown",
         "last_updated": "2026-02-07",
-        "url": "git@github.com:Red-Hat-AI-Innovation-Team/sdg_hub.git",
+        "url": "https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub",
         "agentready_version": "2.25.2",
         "research_version": "1.0.1",
         "history": [
@@ -604,7 +604,7 @@
         "language": "Unknown",
         "size": "Unknown",
         "last_updated": "2026-02-17",
-        "url": "git@github.com:feast-dev/feast.git",
+        "url": "https://github.com/feast-dev/feast",
         "agentready_version": "2.27.3",
         "research_version": "1.0.1",
         "history": [
@@ -618,31 +618,6 @@
         "rank": 5,
         "lang_rank": {
           "Unknown": 5
-        }
-      },
-      {
-        "repo": "jeremyeder/reference",
-        "org": "jeremyeder",
-        "name": "reference",
-        "score": 55.8,
-        "tier": "Bronze",
-        "language": "Unknown",
-        "size": "Unknown",
-        "last_updated": "2026-01-15",
-        "url": "https://github.com/jeremyeder/reference",
-        "agentready_version": "2.22.0",
-        "research_version": "1.0.1",
-        "history": [
-          {
-            "date": "2026-01-15",
-            "score": 55.8,
-            "agentready_version": "2.22.0",
-            "research_version": "1.0.1"
-          }
-        ],
-        "rank": 6,
-        "lang_rank": {
-          "Unknown": 6
         }
       },
       {
@@ -665,6 +640,31 @@
             "research_version": "1.0.1"
           }
         ],
+        "rank": 6,
+        "lang_rank": {
+          "Unknown": 6
+        }
+      },
+      {
+        "repo": "jeremyeder/reference",
+        "org": "jeremyeder",
+        "name": "reference",
+        "score": 55.8,
+        "tier": "Bronze",
+        "language": "Unknown",
+        "size": "Unknown",
+        "last_updated": "2026-01-15",
+        "url": "https://github.com/jeremyeder/reference",
+        "agentready_version": "2.22.0",
+        "research_version": "1.0.1",
+        "history": [
+          {
+            "date": "2026-01-15",
+            "score": 55.8,
+            "agentready_version": "2.22.0",
+            "research_version": "1.0.1"
+          }
+        ],
         "rank": 7,
         "lang_rank": {
           "Unknown": 7
@@ -679,7 +679,7 @@
         "language": "Unknown",
         "size": "Unknown",
         "last_updated": "2025-12-04",
-        "url": "git@github.com:quay/quay.git",
+        "url": "https://github.com/quay/quay",
         "agentready_version": "2.12.2",
         "research_version": "1.0.0",
         "history": [
@@ -704,7 +704,7 @@
         "language": "Unknown",
         "size": "Unknown",
         "last_updated": "2026-01-28",
-        "url": "git@github.com:dgutride/odh-dashboard.git",
+        "url": "https://github.com/dgutride/odh-dashboard",
         "agentready_version": "2.23.0",
         "research_version": "1.0.1",
         "history": [


### PR DESCRIPTION
## Description

Fix the ordering problem in updating the leaderboard data when there is a change to the leaderboard data generate python script in addition to the new submissions.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues

Fixes #298

## Changes Made

- Fix update job condition to run on workflow_dispatch (was only running on push)
- Add generate-leaderboard-data.py to trigger paths for automatic regeneration
- Regenerate leaderboard.json with correct HTTPS URLs (fixes broken links)

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Integration tests pass
- [X] Manual testing performed
- [X] No new warnings or errors

## Checklist

- [X] My code follows the project's code style
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
