### PR TITLE
chore: add kami619 to agentready-dev ACL

### DIFF
--- a/.github/agentready-acl.yml
+++ b/.github/agentready-acl.yml
@@ -2,4 +2,5 @@
 # Add users via pull request to maintain audit trail
 authorized_users:
   - jeremyeder
+  - kami619
   # Add more users here via PR


### PR DESCRIPTION
Add kami619 to the authorized users list for the @agentready-dev agent, allowing them to trigger issue-to-PR automation workflows.

cc: @jeremyeder 
