### PR TITLE
fix: Check for all official commitlint config file formats

### DIFF
--- a/src/agentready/assessors/stub_assessors.py
+++ b/src/agentready/assessors/stub_assessors.py
@@ -236,8 +236,25 @@ class ConventionalCommitsAssessor(BaseAssessor):
         )
 
     def assess(self, repository: Repository) -> Finding:
-        # Simplified: Check if commitlint or husky is configured
-        has_commitlint = (repository.path / ".commitlintrc.json").exists()
+        commitlint_configs = [
+            ".commitlintrc",
+            ".commitlintrc.json",
+            ".commitlintrc.yaml",
+            ".commitlintrc.yml",
+            ".commitlintrc.js",
+            ".commitlintrc.cjs",
+            ".commitlintrc.mjs",
+            ".commitlintrc.ts",
+            ".commitlintrc.cts",
+            "commitlint.config.js",
+            "commitlint.config.cjs",
+            "commitlint.config.mjs",
+            "commitlint.config.ts",
+            "commitlint.config.cts",
+        ]
+        has_commitlint = any(
+            (repository.path / cfg).exists() for cfg in commitlint_configs
+        )
         has_husky = (repository.path / ".husky").exists()
 
         if has_commitlint or has_husky:


### PR DESCRIPTION
## Description

The `ConventionalCommitsAssessor` in agentready was hardcoded to only check for `.commitlintrc.json` and `.husky/`, but the projects using other formats like .`commitlintrc.yaml` - a valid commitlint config format wasn't being recognized.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

Updated the assessor in `src/agentready/assessors/stub_assessors.py` to check for all official commitlint config file formats (.commitlintrc, .commitlintrc.json, .commitlintrc.yaml, .commitlintrc.yml, .commitlintrc.js, .commitlintrc.cjs, .commitlintrc.mjs, .commitlintrc.ts, .commitlintrc.cts, commitlint.config.js, commitlint.config.cjs, commitlint.config.mjs, commitlint.config.ts, commitlint.config.cts).

## Testing

- [x] Unit tests pass (`pytest`)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] No new warnings or errors

## Checklist

- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

