### PR TITLE
fix(security): replace pull_request_target with pull_request trigger

### DIFF
--- a/.github/AUTOMATED_REVIEW.md
+++ b/.github/AUTOMATED_REVIEW.md
@@ -172,24 +172,7 @@ mv .github/workflows/pr-review.yml.disabled .github/workflows/pr-review.yml
 
 ## Customization
 
-### Adjust Confidence Threshold
-
-Edit `.github/workflows/pr-review-auto-fix.yml`:
-
-```yaml
-# Change from 90 to 95 for more conservative auto-fixing
-if: needs.review.outputs.has_criticals == 'true'  # confidence ≥90
-# to
-if: needs.review.outputs.has_criticals == 'true'  # confidence ≥95
-```
-
-Also update `.claude/commands/review-agentready.md`:
-
-```markdown
-**Critical Issue Criteria** (confidence ≥95):  # Changed from 90
-```
-
-### Add Custom Focus Areas
+### Adjust Review Focus Areas
 
 Edit `.claude/commands/review-agentready.md` under "AgentReady-Specific Focus Areas":
 
@@ -222,24 +205,6 @@ class ReviewFormatter:
 2. Verify `ANTHROPIC_API_KEY` is set correctly
 3. Ensure `pull-requests: write` permission is granted
 4. **Fork PRs**: Reviews only run on PRs from branches in the main repo, not forks
-
-### Auto-Fix Not Running
-
-**Symptom**: Review posts but auto-fix job doesn't run
-
-**Solutions**:
-1. Verify review found issues with confidence ≥90
-2. Check `.review-results.json` artifact was uploaded
-3. Review `needs.review.outputs.has_criticals` value in logs
-
-### Fixes Causing Test Failures
-
-**Symptom**: Auto-fix commits but tests fail
-
-**Solutions**:
-1. Check the auto-fix logic in `.github/claude-bot-prompt.md`
-2. Verify linters run before tests: `black . && isort . && pytest`
-3. Consider lowering confidence threshold (fixes might be too aggressive)
 
 ### Rate Limiting
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -9,15 +9,15 @@ name: PR Review
 # For fork contributors: Push your branch to the main repo instead of using
 # a fork, or request manual review.
 #
-# Fixes: RHOAIENG-51622 (security), GitHub #324 (wrong PR context)
-# See: https://issues.redhat.com/browse/RHOAIENG-51622
+# Fixes: GitHub #324 (wrong PR context)
+# Security: Prevents prompt injection attacks from fork PRs
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   issues: write
 


### PR DESCRIPTION
## Summary

- Replace vulnerable `pull_request_target` trigger with secure `pull_request` trigger
- Add explicit PR number in prompt to fix wrong-PR bug
- Update documentation to reflect new security model

## Fixes

- [RHOAIENG-51622](https://issues.redhat.com/browse/RHOAIENG-51622) — Disable pull_request_target to prevent prompt injection
- [#324](https://github.com/ambient-code/agentready/issues/324) — PR review posting to wrong pull request

## Root Cause

The `pr-review-auto-fix.yml` workflow used `pull_request_target` trigger, which:
1. Runs with access to repository secrets even for fork PRs
2. Exposes secrets to potential prompt injection attacks via malicious PR content
3. Combined with ambiguous prompt wording, occasionally posted reviews to wrong PRs

## Changes

| File | Change |
|------|--------|
| `.github/workflows/pr-review.yml` | **Created** — Secure workflow with `pull_request` trigger |
| `.github/workflows/pr-review-auto-fix.yml` | **Deleted** — Removed vulnerable workflow |
| `.github/AUTOMATED_REVIEW.md` | **Updated** — New security model documentation |

## Trade-off

Fork PRs no longer receive automated reviews. Contributors should push to `username/branch` in the main repo instead.

## Test Plan

After merge:
1. Open a PR from a branch in the main repo
2. Verify `PR Review` workflow triggers
3. Verify review comment posts to correct PR
4. (Optional) Verify fork PRs are skipped

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>