### PR TITLE
feat: accept .containerignore as alias for .dockerignore

### DIFF
--- a/src/agentready/assessors/containers.py
+++ b/src/agentready/assessors/containers.py
@@ -29,7 +29,7 @@ class ContainerSetupAssessor(BaseAssessor):
             category="Build & Development",
             tier=self.tier,
             description="Container configuration for consistent development environments",
-            criteria="Dockerfile/Containerfile, docker-compose.yml, .dockerignore, multi-stage builds",
+            criteria="Dockerfile/Containerfile, docker-compose.yml, .dockerignore/.containerignore, multi-stage builds",
             default_weight=0.01,
         )
 
@@ -94,23 +94,27 @@ class ContainerSetupAssessor(BaseAssessor):
             score += 30
             evidence.append(f"✓ Docker Compose configured ({', '.join(found_compose)})")
 
-        # 4. .dockerignore file (20 points)
-        dockerignore = repository.path / ".dockerignore"
-        if dockerignore.exists():
+        # 4. .dockerignore / .containerignore file (20 points)
+        ignore_candidates = [
+            repository.path / ".dockerignore",
+            repository.path / ".containerignore",
+        ]
+        found_ignore = next((p for p in ignore_candidates if p.exists()), None)
+        if found_ignore is not None:
             try:
-                size = dockerignore.stat().st_size
+                size = found_ignore.stat().st_size
                 if size > 0:
                     score += 20
                     evidence.append(
-                        "✓ .dockerignore present (excludes unnecessary files)"
+                        f"✓ {found_ignore.name} present (excludes unnecessary files)"
                     )
                 else:
-                    evidence.append("⚠️ .dockerignore is empty")
+                    evidence.append(f"⚠️ {found_ignore.name} is empty")
             except OSError:
                 pass
         else:
             evidence.append(
-                "ℹ️ No .dockerignore file (consider adding to reduce image size)"
+                "ℹ️ No .dockerignore / .containerignore file (consider adding to reduce image size)"
             )
 
         # Determine status
@@ -123,7 +127,7 @@ class ContainerSetupAssessor(BaseAssessor):
                 summary="Improve container configuration",
                 steps=[
                     "Add docker-compose.yml for multi-service development",
-                    "Create .dockerignore to exclude build artifacts and secrets",
+                    "Create .dockerignore (or .containerignore) to exclude build artifacts and secrets",
                     "Consider multi-stage builds to reduce image size",
                 ],
                 tools=["docker", "podman", "docker-compose"],
@@ -150,13 +154,13 @@ class ContainerSetupAssessor(BaseAssessor):
                 summary="Complete container setup with best practices",
                 steps=[
                     "Add docker-compose.yml for local development",
-                    "Create .dockerignore to exclude unnecessary files",
+                    "Create .dockerignore (or .containerignore) to exclude unnecessary files",
                     "Use multi-stage builds for production images",
                     "Document container usage in README",
                 ],
                 tools=["docker", "podman", "docker-compose"],
                 commands=[
-                    "touch .dockerignore",
+                    "touch .dockerignore  # or .containerignore for Podman",
                     "touch docker-compose.yml",
                 ],
                 examples=[
@@ -177,7 +181,7 @@ class ContainerSetupAssessor(BaseAssessor):
             status=status,
             score=min(score, 100),  # Cap at 100
             measured_value=f"{score} points",
-            threshold="≥70 points (Dockerfile + compose + .dockerignore)",
+            threshold="≥70 points (Dockerfile + compose + .dockerignore/.containerignore)",
             evidence=evidence,
             remediation=remediation,
             error_message=None,

--- a/tests/unit/test_assessors_containers.py
+++ b/tests/unit/test_assessors_containers.py
@@ -198,6 +198,81 @@ node_modules
         assert finding.score == 60  # Dockerfile (40) + .dockerignore (20)
         assert any(".dockerignore present" in e for e in finding.evidence)
 
+    def test_containerignore_file(self, tmp_path):
+        """Test that .containerignore is accepted as an alias for .dockerignore."""
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+
+        (tmp_path / "Dockerfile").write_text("FROM python:3.12\n")
+
+        (tmp_path / ".containerignore").write_text(
+            ".git\n.venv\n__pycache__\n*.pyc\n.env\n"
+        )
+
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=10,
+            total_lines=100,
+        )
+
+        assessor = ContainerSetupAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.score == 60  # Dockerfile (40) + .containerignore (20)
+        assert any(".containerignore present" in e for e in finding.evidence)
+
+    def test_empty_containerignore(self, tmp_path):
+        """Test that an empty .containerignore doesn't get points."""
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+
+        (tmp_path / "Dockerfile").write_text("FROM python:3.12\n")
+        (tmp_path / ".containerignore").write_text("")
+
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=10,
+            total_lines=100,
+        )
+
+        assessor = ContainerSetupAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.score == 40  # Only Dockerfile
+        assert any(".containerignore is empty" in e for e in finding.evidence)
+
+    def test_both_ignore_files_no_double_count(self, tmp_path):
+        """Test that having both .dockerignore and .containerignore awards 20 pts once."""
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+
+        (tmp_path / "Dockerfile").write_text("FROM python:3.12\n")
+        (tmp_path / ".dockerignore").write_text(".git\n.venv\n")
+        (tmp_path / ".containerignore").write_text(".git\n.venv\n")
+
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=10,
+            total_lines=100,
+        )
+
+        assessor = ContainerSetupAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.score == 60  # Dockerfile (40) + ignore file (20), not 80
+
     def test_empty_dockerignore(self, tmp_path):
         """Test that empty .dockerignore doesn't get points."""
         # Initialize git repository


### PR DESCRIPTION
## Description

The container setup assessor now recognises .containerignore (used by Podman and other OCI-compatible tools) alongside .dockerignore when checking for an ignore file. The first match in the candidate list wins; if both files are present the score is still capped at 20 points.

Remediation text, criteria, and threshold strings updated to reflect the dual-name support.

Three new tests added:
- .containerignore present and non-empty → 20 pts
- .containerignore present but empty → 0 pts
- both files present → 20 pts (no double-count)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass (`pytest`)
- [ ] Integration tests pass
- [x] Manual testing performed
- [x] No new warnings or errors

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published