### PR TITLE
chore: remove version from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,6 @@ Assess repositories against evidence-based attributes for AI-assisted developmen
 
 | Item | Value |
 |------|-------|
-| **Version** | 2.29.6 |
 | **Python** | >=3.12 |
 | **Entry Point** | `agentready.cli.main:cli` |
 | **Self-Score** | 80.0/100 (Gold) |


### PR DESCRIPTION
Version is already in `pyproject.toml` and `CHANGELOG.md`. Keeping a third copy in `CLAUDE.md` means it goes stale on every release — it was already one release behind after v2.32.0 merged today. Agents can read `pyproject.toml` themselves.

---
*Filed by Claude Code under the supervision of Bill Murdock.*