### PR TITLE
fix: register RepomixConfigAssessor in create_all_assessors

### DIFF
--- a/src/agentready/assessors/__init__.py
+++ b/src/agentready/assessors/__init__.py
@@ -33,6 +33,7 @@ from .patterns import (
     PatternReferencesAssessor,
     ProgressiveDisclosureAssessor,
 )
+from .repomix import RepomixConfigAssessor
 from .security import DependencySecurityAssessor
 from .structure import (
     IssuePRTemplatesAssessor,
@@ -104,6 +105,7 @@ def create_all_assessors() -> list[BaseAssessor]:
         DbtProjectStructureAssessor(),  # dbt conditional
         # Tier 3 Important — 14% total
         DesignIntentAssessor(),  # NEW (2%)
+        RepomixConfigAssessor(),  # 2%
         CyclomaticComplexityAssessor(),  # 3%
         ArchitectureDecisionsAssessor(),  # 3%
         IssuePRTemplatesAssessor(),  # 3%

--- a/tests/unit/test_repomix.py
+++ b/tests/unit/test_repomix.py
@@ -100,8 +100,10 @@ class TestRepomixService:
 
     def test_get_output_files_found(self, tmp_path):
         """Test getting output files when they exist."""
-        (tmp_path / "repomix-output.md").write_text("content")
-        (tmp_path / "repomix-output.xml").write_text("<xml/>")
+        repomix_dir = tmp_path / "repomix"
+        repomix_dir.mkdir()
+        (repomix_dir / "repomix-output.md").write_text("content")
+        (repomix_dir / "repomix-output.xml").write_text("<xml/>")
 
         service = RepomixService(tmp_path)
         files = service.get_output_files()
@@ -116,7 +118,9 @@ class TestRepomixService:
 
     def test_check_freshness_fresh_file(self, tmp_path):
         """Test freshness check with recent file."""
-        output = tmp_path / "repomix-output.md"
+        repomix_dir = tmp_path / "repomix"
+        repomix_dir.mkdir()
+        output = repomix_dir / "repomix-output.md"
         output.write_text("fresh content")
 
         service = RepomixService(tmp_path)
@@ -223,7 +227,9 @@ class TestRepomixConfigAssessor:
         # Create .git directory, config and output
         (tmp_path / ".git").mkdir()
         (tmp_path / "repomix.config.json").write_text("{}")
-        (tmp_path / "repomix-output.md").write_text("content")
+        repomix_dir = tmp_path / "repomix"
+        repomix_dir.mkdir()
+        (repomix_dir / "repomix-output.md").write_text("content")
 
         repo = Repository(
             path=tmp_path,


### PR DESCRIPTION
## Summary

- Imports and registers `RepomixConfigAssessor` in `create_all_assessors()` so `repomix_config` is recognized as a valid attribute ID
- Fixes three unit tests in `test_repomix.py` that placed output files in the repo root instead of the `repomix/` subdirectory where `RepomixService.get_output_files()` looks

## Test plan

- [x] `pytest tests/e2e/test_critical_paths_simplified.py::TestCriticalConfigHandling::test_valid_config_application` now passes
- [x] `pytest tests/unit/test_repomix.py` all 21 tests pass
- [x] Full test suite passes (1149 passed, 21 skipped)
- [x] `agentready assess .` shows `repomix_config` in results (previously absent)

Closes #400

> Note: a follow-up issue (#403) tracks adding `repomix_config` to `default-weights.yaml` and fixing the `separation_concerns` typo in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code) under the supervision of Bill Murdock