### PR TITLE
fix: correct default-weights.yaml dead key, add repomix_config, document branch_protection

### DIFF
--- a/src/agentready/data/default-weights.yaml
+++ b/src/agentready/data/default-weights.yaml
@@ -47,18 +47,21 @@ one_command_setup: 0.03             # 8.1 - One-Command Build/Setup
 concise_documentation: 0.03         # 1.2 - Concise Structured Documentation
 inline_documentation: 0.03          # 2.2 - Inline Documentation
 file_size_limits: 0.03              # 1.3 - File Size Limits
-separation_concerns: 0.03           # 4.2 - Separation of Concerns
+separation_of_concerns: 0.03        # 4.2 - Separation of Concerns
 pattern_references: 0.03            # 17.1 - Pattern References for Common Changes NEW
 
-# Tier 3 (Important) - 14% total weight
+# Tier 3 (Important) - 14% total weight (6 attributes)
 design_intent: 0.02                 # 17.2 - Design Intent Documentation NEW
-cyclomatic_complexity: 0.03         # 3.1 - Cyclomatic Complexity Thresholds
-structured_logging: 0.03            # 9.2 - Structured Logging
+cyclomatic_complexity: 0.02         # 3.1 - Cyclomatic Complexity Thresholds
+structured_logging: 0.02            # 9.2 - Structured Logging
 openapi_specs: 0.03                 # 10.1 - OpenAPI/Swagger Specifications
 architecture_decisions: 0.03        # 2.3 - Architecture Decision Records
+repomix_config: 0.02                # AI context generation (Repomix)
 
 # Tier 4 (Advanced) - 4% total weight
 code_smells: 0.01                   # 3.4 - Code Smell Elimination
 issue_pr_templates: 0.01            # 7.3 - Issue & Pull Request Templates
 container_setup: 0.01               # 8.3 - Container/Virtualization Setup (conditional)
 progressive_disclosure: 0.01        # 17.3 - Progressive Disclosure (path-scoped rules, skills) NEW
+# branch_protection intentionally omitted: always not_applicable until GitHub API
+# integration is implemented (see issue #405). Uses default_weight=0.005 as fallback.

--- a/src/agentready/data/default-weights.yaml
+++ b/src/agentready/data/default-weights.yaml
@@ -1,6 +1,6 @@
 # Default Tier-Based Weight Distribution
 #
-# This file defines the default weights for all 27 attributes.
+# This file defines the default weights for all 28 attributes.
 # Weights are based on evidence from ETH Zurich (Feb 2026), Anthropic,
 # Red Hat best practices (April 2026), and LangChain Terminal-Bench.
 #
@@ -9,7 +9,7 @@
 #
 # Tier 1 (Essential):  55% total (9 attributes)
 # Tier 2 (Critical):   27% total (3% each, 9 attributes)
-# Tier 3 (Important):  14% total (varies, 5 attributes)
+# Tier 3 (Important):  14% total (varies, 6 attributes)
 # Tier 4 (Advanced):    4% total (1% each, 4 attributes)
 # TOTAL:              100% (sum to 1.0)
 #


### PR DESCRIPTION
## Summary

- **Typo fix**: `separation_concerns` → `separation_of_concerns` to match `SeparationOfConcernsAssessor.attribute_id`. The old key never matched any assessor, causing it to be dead weight in the yaml while the assessor fell back to `default_weight=0.03`.
- **Add `repomix_config: 0.02`**: makes the weight explicit in the yaml now that the assessor is registered (see #400). Weight absorbed within Tier 3 by reducing `cyclomatic_complexity` and `structured_logging` from 0.03 to 0.02 each — Tier 3 total stays at 14%.
- **Document `branch_protection`**: add a comment explaining it is intentionally omitted until GitHub API integration is implemented (see #405).

## Verification

```
Total: 1.0000 across 28 attributes
```

## Test plan

- [x] `python3 -c "import yaml; ..."` confirms weights sum to exactly 1.0
- [x] Full test suite: 1152 passed, 21 skipped

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code) under the supervision of Bill Murdock