### PR TITLE
ci: pin black 26.3.1 across pre-commit and CI, drop Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,24 +11,19 @@ jobs:
   blocking-checks:
     name: Blocking Tests & Quality Checks
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.12', '3.13']
-
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
+          pip install "black==26.3.1"
 
-      # Run code quality checks (only on one Python version to save time)
       - name: Code Quality Checks
-        if: matrix.python-version == '3.13'
         run: |
           black --check .
           isort --check .
@@ -51,7 +46,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |
@@ -82,7 +77,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.12'
 
       - name: Install and test
         run: |
@@ -107,7 +102,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: actionlint
 
   - repo: https://github.com/psf/black
-    rev: 25.11.0
+    rev: 26.3.1
     hooks:
       - id: black
         language_version: python3.12


### PR DESCRIPTION
## Summary

- Upgrade black from 25.11.0 to 26.3.1 in `.pre-commit-config.yaml`
- Pin `black==26.3.1` in CI so it matches pre-commit exactly
- Drop Python 3.13 from CI matrix — standardize on 3.12 only

The root cause: pre-commit pinned black 25.11.0, but CI ran `pip install -e ".[dev]"` which pulled latest black (26.3.1). The two versions disagree on multiline string list formatting, causing spurious CI failures (e.g. #416).

## Test plan

- [x] `black --check .` passes with 26.3.1 (154 files unchanged)
- [ ] CI passes on this PR (single 3.12 job, pinned black)

🤖 Generated with [Claude Code](https://claude.com/claude-code)