### PR TITLE
docs: add self-assign issues guideline to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ Finding.create_fail(self.attribute, evidence="...", remediation="...")
 3. **Test thoroughly** - Unit tests required for all assessors
 4. **Backwards compatibility** - Schema version bump for model changes
 5. **Rich remediation** - Actionable steps with tools, commands, examples
+6. **Self-assign issues** - Before starting work on a GitHub issue, check if it is already assigned. If it is, warn the user and ask for confirmation before continuing. If unassigned (or the user confirms), self-assign it immediately to prevent duplicate effort from other contributors
 
 ## Related Docs
 


### PR DESCRIPTION
## Summary

Adds a guideline to the Agent Guidelines section of `CLAUDE.md` instructing agents to self-assign GitHub issues immediately when starting work on them.

This prevents duplicate effort — we had a contributor (Jeremy Eder) independently implement the same #414 fix while we were working on it in PR #415, because the issue wasn't claimed.

## Test plan

- [ ] No code changes; docs-only

🤖 Generated with [Claude Code](https://claude.ai/claude-code) under the supervision of Bill Murdock

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added agent guideline to self-assign GitHub issues when beginning work, preventing duplicate effort.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->