### PR TITLE
style: fix black formatting left unformatted by #416

### DIFF
--- a/src/agentready/assessors/documentation.py
+++ b/src/agentready/assessors/documentation.py
@@ -479,8 +479,7 @@ class READMEAssessor(BaseAssessor):
             ],
             tools=[],
             commands=[],
-            examples=[
-                """# Project Name
+            examples=["""# Project Name
 
 ## Overview
 What this project does and why it exists.
@@ -503,8 +502,7 @@ pytest
 # Format code
 black .
 ```
-"""
-            ],
+"""],
             citations=[
                 Citation(
                     source="GitHub",


### PR DESCRIPTION
## Summary

PR #416 introduced a string literal formatting change in `documentation.py` that does not satisfy `black`. This caused CI to fail on every subsequent PR against main.

Two-line whitespace fix — no logic changes.

## Test plan

- [ ] CI passes (black check green)

🤖 Generated with [Claude Code](https://claude.ai/claude-code) under the supervision of Bill Murdock