### PR TITLE
docs: add guideline to keep docs/attributes.md in sync with scorer changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ Finding.create_fail(self.attribute, evidence="...", remediation="...")
 4. **Backwards compatibility** - Schema version bump for model changes
 5. **Rich remediation** - Actionable steps with tools, commands, examples
 6. **Self-assign issues** - Before starting work on a GitHub issue, check if it is already assigned. If it is, warn the user and ask for confirmation before continuing. If unassigned (or the user confirms), self-assign it immediately to prevent duplicate effort from other contributors
+7. **Keep docs/attributes.md in sync** - When changing how an assessor scores (thresholds, partial credit rules, recognized paths, pass/fail conditions), update the corresponding entry in `docs/attributes.md` in the same PR
 
 ## Related Docs
 


### PR DESCRIPTION
## Summary

Adds a guideline to the Agent Guidelines section of CLAUDE.md requiring that
any change to how an assessor scores (thresholds, partial credit rules,
recognized paths, pass/fail conditions) is accompanied by a matching update
to docs/attributes.md in the same PR.

## Motivation

PR #419 updated the partial-credit gate for `architecture_decisions` from an
OR condition to an AND condition, but the corresponding docs/attributes.md
entry was not updated in the same commit — it had to be caught and fixed
separately. This guideline prevents that from happening again.

🤖 Generated with [Claude Code](https://claude.ai/claude-code) under the supervision of Bill Murdock