### PR TITLE
fix: remove hardcoded attribute count limits from assessment schema

### DIFF
--- a/specs/001-agentready-scorer/contracts/assessment-schema.json
+++ b/specs/001-agentready-scorer/contracts/assessment-schema.json
@@ -57,31 +57,26 @@
     },
     "attributes_assessed": {
       "type": "integer",
-      "minimum": 0,
-      "maximum": 25
+      "minimum": 0
     },
     "attributes_skipped": {
       "type": "integer",
       "minimum": 0,
-      "maximum": 25,
       "description": "Canonical key name for skipped/not-assessed attributes"
     },
     "attributes_not_assessed": {
       "type": "integer",
       "minimum": 0,
-      "maximum": 25,
       "description": "Deprecated alias for attributes_skipped (backwards compatibility)"
     },
     "attributes_total": {
       "type": "integer",
       "minimum": 10,
-      "maximum": 25,
-      "description": "Total attributes in assessment (may be < 25 if --exclude was used)"
+      "description": "Total attributes in assessment (may be fewer if --exclude was used)"
     },
     "findings": {
       "type": "array",
       "minItems": 10,
-      "maxItems": 25,
       "items": {
         "type": "object",
         "required": ["attribute", "status"],


### PR DESCRIPTION
## Summary

- Removes `maximum: 25` from `attributes_assessed`, `attributes_skipped`, `attributes_not_assessed`, and `attributes_total` in the assessment JSON schema
- Removes `maxItems: 25` from the `findings` array
- Updates a stale description that referenced the old limit

## Why

The validate CI job was failing on all submissions generated by v2.36.1, which produces assessments with 33 attributes. The schema was written when the tool had 25 assessors and was never updated as new ones were added. Hardcoding this limit means the schema breaks every time a new assessor is added.

## Test plan

- [ ] CI validate job passes on PR #424 after this merges

🤖 Generated with [Claude Code](https://claude.ai/code) under the supervision of Bill Murdock

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated validation constraints for assessment data by removing upper bounds on attribute counts and findings collections. The system now supports larger assessment datasets and provides increased flexibility for data capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->