### PR TITLE
feat: add pdm.lock to recognized lockfiles

### DIFF
--- a/src/agentready/assessors/stub_assessors.py
+++ b/src/agentready/assessors/stub_assessors.py
@@ -56,6 +56,7 @@ class DependencyPinningAssessor(BaseAssessor):
             "Cargo.lock",  # Rust
             "Gemfile.lock",  # Ruby
             "go.sum",  # Go
+            "pdm.lock",  # pdm
         ]
 
         # Manual lock files (need validation)


### PR DESCRIPTION
## Description

Adding pdm.lock to recognized Python lockfiles

## Changes Made

- Added `pdm.lock` to the lockfiles list in `src/agentready/assessors/stub_assessors.py`

## Testing

- tested against local project which utilizes PDM Python package manager 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed assessment of repositories using PDM package manager to correctly identify them as having strict, pinned-version dependency lock files instead of falling back to manual dependency checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->