### PR TITLE
fix: Exclude .tox from separation of concerns check

### DIFF
--- a/src/agentready/assessors/structure.py
+++ b/src/agentready/assessors/structure.py
@@ -1052,7 +1052,7 @@ class SeparationOfConcernsAssessor(BaseAssessor):
                 # Skip venv, node_modules, etc.
                 if any(
                     part in py_file.parts
-                    for part in [".venv", "venv", "node_modules", ".git"]
+                    for part in [".venv", "venv", "node_modules", ".git", ".tox"]
                 ):
                     continue
 
@@ -1091,7 +1091,7 @@ class SeparationOfConcernsAssessor(BaseAssessor):
                     for m in matches
                     if not any(
                         part in m.parts
-                        for part in [".venv", "venv", "node_modules", ".git"]
+                        for part in [".venv", "venv", "node_modules", ".git", ".tox"]
                     )
                 ]
                 if matches:


### PR DESCRIPTION
## Description

Similar as .venv, .tox contains only temporary files which are not part of the project - not excluding this directory leads to false negative in Separation of Concerns check.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- added `.tox` to `src/agentready/assessors/structure.py

## Testing

Ran against local project with `.tox` -  separation_of_concerns check passed after the change (original report: `File cohesion: 9346/59348 files >500 lines`)

- [x] Unit tests pass (`pytest`)
- [ ] Integration tests pass
- [x] Manual testing performed
- [ ] No new warnings or errors

## Checklist

- [ ] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The separation-of-concerns assessor now correctly excludes `.tox` directories from code quality analysis, preventing false positives in test environment files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->