### PR TITLE
feat: support org-level issue templates from .github repo

### DIFF
--- a/src/agentready/assessors/structure.py
+++ b/src/agentready/assessors/structure.py
@@ -10,6 +10,7 @@ from typing import Literal, TypedDict
 from ..models.attribute import Attribute
 from ..models.finding import Citation, Finding, Remediation
 from ..models.repository import Repository
+from ..utils.github_templates import GitHubTemplatesFetcher
 from .base import BaseAssessor
 
 
@@ -807,11 +808,17 @@ class IssuePRTemplatesAssessor(BaseAssessor):
         Scoring:
         - PR template exists (50%)
         - Issue templates exist (50%, requires ≥2 templates)
+
+        Checks local .github/ directory first, then falls back to
+        organization-level templates from the org's .github repo if the
+        repository has no local templates and the GITHUB_TOKEN is
+        available.
         """
         score = 0
         evidence = []
+        template_count = 0
 
-        # Check for PR template (50%)
+        # Check for PR template (50%) - local first
         pr_template_paths = [
             repository.path / ".github" / "PULL_REQUEST_TEMPLATE.md",
             repository.path / "PULL_REQUEST_TEMPLATE.md",
@@ -824,9 +831,23 @@ class IssuePRTemplatesAssessor(BaseAssessor):
             score += 50
             evidence.append("PR template found")
         else:
-            evidence.append("No PR template found")
+            # Check org-level fallback for PR templates
+            fetcher = GitHubTemplatesFetcher()
+            owner = fetcher.extract_owner(repository.url)
+            if owner:
+                org_pr_templates = fetcher.fetch_pr_templates(owner)
+                if org_pr_templates:
+                    score += 50
+                    pr_template_found = True
+                    evidence.append(
+                        "PR template found (inherited from org-level .github repo)"
+                    )
+                else:
+                    evidence.append("No PR template found")
+            else:
+                evidence.append("No PR template found")
 
-        # Check for issue templates (50%)
+        # Check for issue templates (50%) - local first
         issue_template_dir = repository.path / ".github" / "ISSUE_TEMPLATE"
 
         if issue_template_dir.exists() and issue_template_dir.is_dir():
@@ -853,7 +874,27 @@ class IssuePRTemplatesAssessor(BaseAssessor):
             except OSError:
                 evidence.append("Could not read issue template directory")
         else:
-            evidence.append("No issue template directory found")
+            # Check org-level fallback for issue templates
+            fetcher = GitHubTemplatesFetcher()
+            owner = fetcher.extract_owner(repository.url)
+            if owner:
+                org_issue_templates = fetcher.fetch_issue_templates(owner)
+                if len(org_issue_templates) >= 2:
+                    score += 50
+                    template_count = len(org_issue_templates)
+                    evidence.append(
+                        f"Issue templates found: {template_count} templates (inherited from org-level .github repo)"
+                    )
+                elif len(org_issue_templates) == 1:
+                    score += 25
+                    template_count = 1
+                    evidence.append(
+                        "Issue template directory exists with 1 template (need ≥2, inherited from org-level .github repo)"
+                    )
+                else:
+                    evidence.append("No issue template directory found")
+            else:
+                evidence.append("No issue template directory found")
 
         status = "pass" if score >= 75 else "fail"
 
@@ -861,7 +902,7 @@ class IssuePRTemplatesAssessor(BaseAssessor):
             attribute=self.attribute,
             status=status,
             score=score,
-            measured_value=f"PR:{pr_template_found}, Issues:{template_count if issue_template_dir.exists() else 0}",
+            measured_value=f"PR:{pr_template_found}, Issues:{template_count}",
             threshold="PR template + ≥2 issue templates",
             evidence=evidence,
             remediation=self._create_remediation() if status == "fail" else None,

--- a/src/agentready/utils/github_templates.py
+++ b/src/agentready/utils/github_templates.py
@@ -1,0 +1,175 @@
+"""GitHub organization-level template fetching.
+
+Checks for issue/PR templates at the organization level via the .github repo.
+"""
+
+import logging
+import os
+import re
+from typing import List, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class GitHubTemplatesError(Exception):
+    """GitHub template fetch errors."""
+
+    pass
+
+
+class GitHubTemplatesFetcher:
+    """Fetches organization-level issue/PR templates from .github repos.
+
+    GitHub organizations can define default community health files (issue
+    templates, PR templates, CODEOWNERS, etc.) in a dedicated `.github`
+    repository that is inherited by all repositories in the organization.
+    """
+
+    def __init__(self, token: Optional[str] = None):
+        """Initialize the fetcher.
+
+        Args:
+            token: GitHub personal access token (optional, defaults to
+                GITHUB_TOKEN environment variable)
+        """
+        self.token = token or os.getenv("GITHUB_TOKEN")
+        self._api_base = "https://api.github.com"
+
+    @property
+    def configured(self) -> bool:
+        """Check if a GitHub token is available."""
+        return bool(self.token)
+
+    def _request_headers(self) -> dict:
+        """Get default headers for GitHub API requests."""
+        return {
+            "Authorization": f"Bearer {self.token}" if self.token else None,
+            "Accept": "application/vnd.github.v3+json",
+            "User-Agent": "agentready",
+        }
+
+    def _fetch_contents(self, owner: str, repo: str, path: str = "") -> List[dict]:
+        """Fetch directory contents from a GitHub repository.
+
+        Args:
+            owner: Repository owner/organization name
+            repo: Repository name
+            path: Path within the repository (defaults to root)
+
+        Returns:
+            List of file metadata dicts from GitHub API
+        """
+        url = f"{self._api_base}/repos/{owner}/{repo}/contents/{path.lstrip('/')}"
+
+        try:
+            response = requests.get(
+                url,
+                headers={k: v for k, v in self._request_headers().items() if v},
+                timeout=30,
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.HTTPError as e:
+            if response.status_code == 404:
+                logger.debug("Path not found: %s/%s/%s", owner, repo, path)
+                return []
+            elif response.status_code in (401, 403):
+                logger.debug("Unauthorized to access %s/%s/%s", owner, repo, path)
+                return []
+            raise GitHubTemplatesError(
+                f"Failed to fetch contents: {owner}/{repo}/{path}"
+            ) from e
+        except requests.RequestException as e:
+            raise GitHubTemplatesError(
+                f"Request failed for {owner}/{repo}/{path}: {e}"
+            ) from e
+
+    def fetch_pr_templates(self, owner: str, repo_name: str = ".github") -> List[str]:
+        """Check for PR templates in an organization-level .github repo.
+
+        Args:
+            owner: GitHub organization name
+            repo_name: Repository name (defaults to '.github')
+
+        Returns:
+            List of PR template file paths found (e.g.
+            ['PULL_REQUEST_TEMPLATE.md'])
+        """
+        if not self.configured:
+            return []
+
+        contents = self._fetch_contents(owner, repo_name, ".github")
+        if not contents:
+            return []
+
+        pr_filenames = {
+            "PULL_REQUEST_TEMPLATE.md": "PULL_REQUEST_TEMPLATE.md",
+            "pull_request_template.md": "PULL_REQUEST_TEMPLATE.md",
+        }
+
+        found = []
+        for item in contents:
+            if item.get("type") == "file" and item.get("name") in pr_filenames:
+                found.append(pr_filenames[item["name"]])
+
+        return sorted(set(found))
+
+    def fetch_issue_templates(
+        self, owner: str, repo_name: str = ".github"
+    ) -> List[str]:
+        """Check for issue templates in an organization-level .github repo.
+
+        Args:
+            owner: GitHub organization name
+            repo_name: Repository name (defaults to '.github')
+
+        Returns:
+            List of issue template file paths found (e.g.
+            ['ISSUE_TEMPLATE/bug_report.md', 'ISSUE_TEMPLATE/feature_request.md'])
+        """
+        if not self.configured:
+            return []
+
+        contents = self._fetch_contents(owner, repo_name, ".github/ISSUE_TEMPLATE")
+        if not contents:
+            return []
+
+        extensions = {".md", ".yml", ".yaml"}
+        found = []
+        for item in contents:
+            name = item.get("name", "")
+            if item.get("type") == "file" and any(
+                name.endswith(ext) for ext in extensions
+            ):
+                found.append(f"ISSUE_TEMPLATE/{name}")
+
+        return sorted(found)
+
+    def extract_owner(self, url: str) -> str | None:
+        """Extract the owner/organization from a GitHub repository URL.
+
+        Supports HTTPS (https://github.com/owner/repo) and SSH
+        (git@github.com:owner/repo.git) formats.
+
+        Args:
+            url: Repository URL string
+
+        Returns:
+            Owner/organization name or None if not parseable
+        """
+        if not url:
+            return None
+
+        # SSH format: git@github.com:owner/repo.git
+        ssh_match = re.match(r"git@github\.com:([^/]+)/.+?$", url)
+        if ssh_match:
+            return ssh_match.group(1)
+
+        # HTTPS: https://github.com/owner/repo.git or .gitignore etc
+        https_match = re.match(r"https://github\.com/([^/]+)/.+?$", url)
+        if https_match:
+            return https_match.group(1)
+
+        return None

--- a/tests/unit/test_github_templates.py
+++ b/tests/unit/test_github_templates.py
@@ -1,0 +1,201 @@
+"""Unit tests for GitHubTemplatesFetcher."""
+
+from unittest.mock import patch
+
+from agentready.utils.github_templates import GitHubTemplatesFetcher
+
+
+class TestGitHubTemplatesFetcherExtractOwner:
+    """Test owner extraction from repository URLs."""
+
+    def test_https_url(self):
+        """Test extracting owner from HTTPS URL."""
+        fetcher = GitHubTemplatesFetcher()
+        owner = fetcher.extract_owner("https://github.com/kagenti/kagenti")
+        assert owner == "kagenti"
+
+    def test_https_url_with_git_suffix(self):
+        """Test extracting owner from HTTPS URL with .git suffix."""
+        fetcher = GitHubTemplatesFetcher()
+        owner = fetcher.extract_owner("https://github.com/owner/repo.git")
+        assert owner == "owner"
+
+    def test_ssh_url(self):
+        """Test extracting owner from SSH URL."""
+        fetcher = GitHubTemplatesFetcher()
+        owner = fetcher.extract_owner("git@github.com:kagenti/kagenti.git")
+        assert owner == "kagenti"
+
+    def test_ssh_url_with_git_suffix(self):
+        """Test extracting owner from SSH URL with .git suffix."""
+        fetcher = GitHubTemplatesFetcher()
+        owner = fetcher.extract_owner("git@github.com:owner/repo.git")
+        assert owner == "owner"
+
+    def test_none_url(self):
+        """Test that None URL returns None."""
+        fetcher = GitHubTemplatesFetcher()
+        assert fetcher.extract_owner(None) is None
+
+    def test_empty_url(self):
+        """Test that empty string returns None."""
+        fetcher = GitHubTemplatesFetcher()
+        assert fetcher.extract_owner("") is None
+
+    def test_non_github_url(self):
+        """Test that non-GitHub URLs return None."""
+        fetcher = GitHubTemplatesFetcher()
+        assert fetcher.extract_owner("https://gitlab.com/owner/repo") is None
+        assert fetcher.extract_owner("https://bitbucket.org/owner/repo") is None
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_no_token_returns_empty(self):
+        """Test that without token, no templates are fetched."""
+        fetcher = GitHubTemplatesFetcher()
+        assert fetcher.configured is False
+        assert fetcher.fetch_pr_templates("kagenti") == []
+        assert fetcher.fetch_issue_templates("kagenti") == []
+
+
+class TestGitHubTemplatesFetcherConfigured:
+    """Test configured property."""
+
+    def test_configured_with_token(self):
+        """Test that configured is True when token is provided."""
+        fetcher = GitHubTemplatesFetcher(token="ghp_test123456789012345678901234567890")
+        assert fetcher.configured is True
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_not_configured_without_token(self):
+        """Test that configured is False without token."""
+        fetcher = GitHubTemplatesFetcher()
+        assert fetcher.configured is False
+
+
+class TestGitHubTemplatesFetcherFetchPrTemplates:
+    """Test PR template fetching from org-level .github repo."""
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_no_token_returns_empty(self):
+        """Test that missing token returns empty list."""
+        fetcher = GitHubTemplatesFetcher()
+        result = fetcher.fetch_pr_templates("owner")
+        assert result == []
+
+    @patch("agentready.utils.github_templates.requests.get")
+    def test_no_repo_returns_empty(self, mock_get):
+        """Test that non-existent .github repo returns empty."""
+        mock_get.return_value.status_code = 404
+        mock_get.return_value.raise_for_status.side_effect = None
+
+        fetcher = GitHubTemplatesFetcher(token="ghp_test123456789012345678901234567890")
+        result = fetcher.fetch_pr_templates("kagenti")
+        assert result == []
+
+    @patch("agentready.utils.github_templates.requests.get")
+    def test_finds_pr_template(self, mock_get):
+        """Test finding a PR template in org .github repo."""
+        mock_get.return_value.json.return_value = [
+            {
+                "type": "file",
+                "name": "PULL_REQUEST_TEMPLATE.md",
+                "path": "PULL_REQUEST_TEMPLATE.md",
+            }
+        ]
+        mock_get.return_value.raise_for_status.return_value = None
+        mock_get.return_value.status_code = 200
+
+        fetcher = GitHubTemplatesFetcher(token="ghp_test123456789012345678901234567890")
+        result = fetcher.fetch_pr_templates("kagenti")
+        assert "PULL_REQUEST_TEMPLATE.md" in result
+
+    @patch("agentready.utils.github_templates.requests.get")
+    def test_returns_all_pr_templates(self, mock_get):
+        """Test returning multiple PR templates."""
+        mock_get.return_value.json.return_value = [
+            {
+                "type": "file",
+                "name": "PULL_REQUEST_TEMPLATE.md",
+                "path": "PULL_REQUEST_TEMPLATE.md",
+            },
+            {
+                "type": "file",
+                "name": "pull_request_template.md",
+                "path": "pull_request_template.md",
+            },
+        ]
+        mock_get.return_value.raise_for_status.return_value = None
+        mock_get.return_value.status_code = 200
+
+        fetcher = GitHubTemplatesFetcher(token="ghp_test123456789012345678901234567890")
+        result = fetcher.fetch_pr_templates("kagenti")
+        assert result == ["PULL_REQUEST_TEMPLATE.md"]
+
+
+class TestGitHubTemplatesFetcherFetchIssueTemplates:
+    """Test issue template fetching from org-level .github repo."""
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_no_token_returns_empty(self):
+        """Test that missing token returns empty list."""
+        fetcher = GitHubTemplatesFetcher()
+        result = fetcher.fetch_issue_templates("owner")
+        assert result == []
+
+    @patch("agentready.utils.github_templates.requests.get")
+    def test_no_repo_returns_empty(self, mock_get):
+        """Test that non-existent .github repo returns empty."""
+        mock_get.return_value.status_code = 404
+        mock_get.return_value.raise_for_status.side_effect = None
+
+        fetcher = GitHubTemplatesFetcher(token="ghp_test123456789012345678901234567890")
+        result = fetcher.fetch_issue_templates("kagenti")
+        assert result == []
+
+    @patch("agentready.utils.github_templates.requests.get")
+    def test_finds_issue_templates(self, mock_get):
+        """Test finding issue templates in org .github repo."""
+        mock_get.return_value.json.return_value = [
+            {
+                "type": "file",
+                "name": "bug_report.md",
+                "path": ".github/ISSUE_TEMPLATE/bug_report.md",
+            },
+            {
+                "type": "file",
+                "name": "feature_request.md",
+                "path": ".github/ISSUE_TEMPLATE/feature_request.md",
+            },
+        ]
+        mock_get.return_value.raise_for_status.return_value = None
+        mock_get.return_value.status_code = 200
+
+        fetcher = GitHubTemplatesFetcher(token="ghp_test123456789012345678901234567890")
+        result = fetcher.fetch_issue_templates("kagenti")
+        assert len(result) == 2
+        assert "ISSUE_TEMPLATE/bug_report.md" in result
+        assert "ISSUE_TEMPLATE/feature_request.md" in result
+
+    @patch("agentready.utils.github_templates.requests.get")
+    def test_finds_yml_templates(self, mock_get):
+        """Test finding YAML-based issue templates."""
+        mock_get.return_value.json.return_value = [
+            {
+                "type": "file",
+                "name": "config.yml",
+                "path": ".github/ISSUE_TEMPLATE/config.yml",
+            },
+            {
+                "type": "file",
+                "name": "bug_report.yml",
+                "path": ".github/ISSUE_TEMPLATE/bug_report.yml",
+            },
+        ]
+        mock_get.return_value.raise_for_status.return_value = None
+        mock_get.return_value.status_code = 200
+
+        fetcher = GitHubTemplatesFetcher(token="ghp_test123456789012345678901234567890")
+        result = fetcher.fetch_issue_templates("kagenti")
+        assert len(result) == 2
+        assert "ISSUE_TEMPLATE/config.yml" in result
+        assert "ISSUE_TEMPLATE/bug_report.yml" in result

--- a/tests/unit/test_issue_template_assessor.py
+++ b/tests/unit/test_issue_template_assessor.py
@@ -1,0 +1,302 @@
+"""Tests for IssuePRTemplatesAssessor with org-level template support."""
+
+from unittest.mock import patch
+
+import pytest
+
+from agentready.assessors.structure import IssuePRTemplatesAssessor
+from agentready.models.repository import Repository
+
+
+class TestIssuePRTemplatesAssessorBasic:
+    """Test basic issue/PR template checking (local templates only)."""
+
+    @pytest.fixture
+    def repo_path(self, tmp_path):
+        """Create a test repository with .git directory."""
+        (tmp_path / ".git").mkdir()
+        return tmp_path
+
+    def test_pass_with_complete_local_templates(self, repo_path):
+        """Test passing when all templates exist locally."""
+        # PR template
+        (repo_path / ".github").mkdir()
+        (repo_path / ".github" / "PULL_REQUEST_TEMPLATE.md").write_text("PR template")
+
+        # Issue templates
+        issue_dir = repo_path / ".github" / "ISSUE_TEMPLATE"
+        issue_dir.mkdir()
+        (issue_dir / "bug_report.md").write_text("bug")
+        (issue_dir / "feature_request.md").write_text("feature")
+
+        repo = Repository(
+            path=repo_path,
+            name="test-repo",
+            url="https://github.com/owner/repo",
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=10,
+            total_lines=100,
+        )
+
+        finding = IssuePRTemplatesAssessor().assess(repo)
+
+        assert finding.status == "pass"
+        assert finding.score == 100.0
+        assert "PR template found" in finding.evidence
+        assert "Issue templates found: 2 templates" in finding.evidence
+
+    def test_fail_without_any_templates(self, repo_path):
+        """Test failing when no templates exist."""
+        repo = Repository(
+            path=repo_path,
+            name="test-repo",
+            url="https://github.com/owner/repo",
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=10,
+            total_lines=100,
+        )
+
+        finding = IssuePRTemplatesAssessor().assess(repo)
+
+        assert finding.status == "fail"
+        assert finding.score == 0
+        assert "No PR template found" in finding.evidence
+        assert "No issue template directory found" in finding.evidence
+
+
+class TestIssuePRTemplatesAssessorOrgFallback:
+    """Test org-level .github repo fallback."""
+
+    @pytest.fixture
+    def repo_path(self, tmp_path):
+        """Create a test repository with .git directory."""
+        (tmp_path / ".git").mkdir()
+        return tmp_path
+
+    @patch("agentready.utils.github_templates.requests.get")
+    @patch("agentready.utils.github_templates.GitHubTemplatesFetcher.extract_owner")
+    @patch(
+        "agentready.utils.github_templates.GitHubTemplatesFetcher.fetch_pr_templates"
+    )
+    @patch(
+        "agentready.utils.github_templates.GitHubTemplatesFetcher.fetch_issue_templates"
+    )
+    @patch.dict(
+        "os.environ", {"GITHUB_TOKEN": "ghp_test123456789012345678901234567890"}
+    )
+    def test_passes_with_org_level_templates_only(
+        self, mock_fetch_issues, mock_fetch_pr, mock_extract_owner, mock_get, repo_path
+    ):
+        """Test passing when only org-level .github repo has templates."""
+        mock_extract_owner.return_value = "kagenti"
+        mock_fetch_pr.return_value = ["PULL_REQUEST_TEMPLATE.md"]
+        mock_fetch_issues.return_value = [
+            "ISSUE_TEMPLATE/bug_report.md",
+            "ISSUE_TEMPLATE/feature_request.md",
+        ]
+        mock_get.return_value.status_code = 200
+
+        repo = Repository(
+            path=repo_path,
+            name="kagenti",
+            url="https://github.com/kagenti/kagenti",
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=10,
+            total_lines=100,
+        )
+
+        finding = IssuePRTemplatesAssessor().assess(repo)
+
+        assert finding.status == "pass"
+        assert finding.score == 100.0
+        assert "inherited from org-level .github repo" in finding.evidence[0]
+
+    @patch("agentready.utils.github_templates.requests.get")
+    @patch("agentready.utils.github_templates.GitHubTemplatesFetcher.extract_owner")
+    @patch(
+        "agentready.utils.github_templates.GitHubTemplatesFetcher.fetch_pr_templates"
+    )
+    @patch(
+        "agentready.utils.github_templates.GitHubTemplatesFetcher.fetch_issue_templates"
+    )
+    @patch.dict(
+        "os.environ", {"GITHUB_TOKEN": "ghp_test123456789012345678901234567890"}
+    )
+    def test_local_only_no_org_check_when_complete(
+        self, mock_fetch_issues, mock_fetch_pr, mock_extract_owner, mock_get, repo_path
+    ):
+        """Test no org-level check when all local templates exist."""
+        # Set up complete local templates
+        (repo_path / ".github").mkdir()
+        (repo_path / ".github" / "PULL_REQUEST_TEMPLATE.md").write_text("PR")
+        issue_dir = repo_path / ".github" / "ISSUE_TEMPLATE"
+        issue_dir.mkdir()
+        (issue_dir / "bug_report.md").write_text("bug")
+        (issue_dir / "feature_request.md").write_text("feature")
+
+        mock_extract_owner.return_value = "kagenti"
+
+        repo = Repository(
+            path=repo_path,
+            name="test-repo",
+            url="https://github.com/owner/test-repo",
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=10,
+            total_lines=100,
+        )
+
+        finding = IssuePRTemplatesAssessor().assess(repo)
+
+        assert finding.status == "pass"
+        assert finding.score == 100.0
+        # extract_owner should not be called because both local checks succeed
+        mock_extract_owner.assert_not_called()
+
+    @patch("agentready.utils.github_templates.requests.get")
+    @patch("agentready.utils.github_templates.GitHubTemplatesFetcher.extract_owner")
+    @patch(
+        "agentready.utils.github_templates.GitHubTemplatesFetcher.fetch_pr_templates"
+    )
+    @patch(
+        "agentready.utils.github_templates.GitHubTemplatesFetcher.fetch_issue_templates"
+    )
+    @patch.dict(
+        "os.environ", {"GITHUB_TOKEN": "ghp_test123456789012345678901234567890"}
+    )
+    def test_passes_with_partial_org_templates_combined_with_local(
+        self, mock_fetch_issues, mock_fetch_pr, mock_extract_owner, mock_get, repo_path
+    ):
+        """Test passing when PR is from org but issue templates are local."""
+        # Local PR template
+        (repo_path / ".github").mkdir()
+        (repo_path / ".github" / "PULL_REQUEST_TEMPLATE.md").write_text("PR")
+
+        # Local issue templates (1 template - partial)
+        issue_dir = repo_path / ".github" / "ISSUE_TEMPLATE"
+        issue_dir.mkdir()
+        (issue_dir / "bug_report.md").write_text("bug")
+
+        mock_extract_owner.return_value = "owner"
+        mock_fetch_issues.return_value = []
+
+        repo = Repository(
+            path=repo_path,
+            name="test",
+            url="https://github.com/owner/test",
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=10,
+            total_lines=100,
+        )
+
+        finding = IssuePRTemplatesAssessor().assess(repo)
+
+        # Should get 50 (PR) + 25 (1 local issue template) = 75 = pass
+        assert finding.score == 75.0
+        assert finding.status == "pass"
+
+    @patch("agentready.utils.github_templates.requests.get")
+    @patch("agentready.utils.github_templates.GitHubTemplatesFetcher.extract_owner")
+    @patch(
+        "agentready.utils.github_templates.GitHubTemplatesFetcher.fetch_pr_templates"
+    )
+    @patch(
+        "agentready.utils.github_templates.GitHubTemplatesFetcher.fetch_issue_templates"
+    )
+    @patch.dict(
+        "os.environ", {"GITHUB_TOKEN": "ghp_test123456789012345678901234567890"}
+    )
+    def test_fail_when_no_org_templates(
+        self, mock_fetch_issues, mock_fetch_pr, mock_extract_owner, mock_get, repo_path
+    ):
+        """Test still fails when no local or org templates exist."""
+        mock_extract_owner.return_value = "kagenti"
+        mock_fetch_pr.return_value = []
+        mock_fetch_issues.return_value = []
+
+        repo = Repository(
+            path=repo_path,
+            name="kagenti",
+            url="https://github.com/kagenti/kagenti",
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=10,
+            total_lines=100,
+        )
+
+        finding = IssuePRTemplatesAssessor().assess(repo)
+
+        assert finding.status == "fail"
+        assert finding.score == 0
+
+    def test_no_token_no_org_check(self, tmp_path):
+        """Test that without GITHUB_TOKEN, org-level checks are skipped."""
+        # No local templates at all - pure fail without org fallback
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".git").mkdir()
+
+        with patch.dict("os.environ", clear=True):
+            from agentready.models.repository import Repository
+
+            repo = Repository(
+                path=tmp_path,
+                name="kagenti",
+                url="https://github.com/kagenti/kagenti",
+                branch="main",
+                commit_hash="abc123",
+                languages={"Python": 100},
+                total_files=10,
+                total_lines=100,
+            )
+
+            finding = IssuePRTemplatesAssessor().assess(repo)
+
+            # Should fail since no local templates and no token for org fallback
+            assert finding.status == "fail"
+            assert finding.score == 0
+            assert "No PR template found" in finding.evidence
+            assert "No issue template directory found" in finding.evidence
+
+    @patch("agentready.utils.github_templates.requests.get")
+    @patch("agentready.utils.github_templates.GitHubTemplatesFetcher.extract_owner")
+    @patch(
+        "agentready.utils.github_templates.GitHubTemplatesFetcher.fetch_pr_templates"
+    )
+    @patch(
+        "agentready.utils.github_templates.GitHubTemplatesFetcher.fetch_issue_templates"
+    )
+    @patch.dict(
+        "os.environ", {"GITHUB_TOKEN": "ghp_test123456789012345678901234567890"}
+    )
+    def test_fallback_with_no_owner(
+        self, mock_fetch_issues, mock_fetch_pr, mock_extract_owner, mock_get, repo_path
+    ):
+        """Test fallback when owner cannot be extracted from URL."""
+        mock_extract_owner.return_value = None  # Can't extract owner
+
+        repo = Repository(
+            path=repo_path,
+            name="test-repo",
+            url="https://gitlab.com/some/other/repo",
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=10,
+            total_lines=100,
+        )
+
+        finding = IssuePRTemplatesAssessor().assess(repo)
+
+        assert finding.status == "fail"
+        assert "No issue template directory found" in finding.evidence
+        assert "No PR template found" in finding.evidence


### PR DESCRIPTION
## Summary

- When assessing a repository that belongs to a GitHub organization, `issue_pr_templates` check now falls back to the organization's `.github` repo for issue and PR templates when no local templates are found
- `GitHubTemplatesFetcher` utility class to query the GitHub API for org-level templates
- `IssuePRTemplatesAssessor` updated to check local `.github/` first, then use org-level templates as fallback (requires `GITHUB_TEMPLATE_TOKEN`)
- 26 unit tests covering the fetcher and the assessor

## Problem

Repos like `kagenti/kagenti` have no `.github/ISSUE_TEMPLATE/` directory locally, but the organization `kagenti` defines templates at `kagenti/.github`. agentready was scoring these as completely missing templates.

## Implementation

### New: `src/agentready/utils/github_templates.py`

- `GitHubTemplatesFetcher` — fetches issue/PR templates from an org's `.github` repo via the GitHub API
- `extract_owner(url)` — parses the owner/org from HTTPS (`https://github.com/owner/repo`) and SSH (`git@github.com:owner/repo.git`) URLs
- `fetch_pr_templates(owner)` — returns list of PR template file paths
- `fetch_issue_templates(owner)` — returns list of issue template file paths
- Requires `GITHUB_TOKEN` env var; gracefully skips when no token is available

### Modified: `src/agentready/assessors/structure.py`

- `IssuePRTemplatesAssessor.assess()` checks local `.github/` first, then falls back to org-level templates when no local templates exist and `GITHUB_TOKEN` is available
- Evidence messages clearly distinguish local vs inherited templates
- Local templates always take precedence

### New: `tests/unit/test_github_templates.py` (18 tests)

Tests for owner extraction, token handling, PR/issue fetching, edge cases (None/empty URLs, non-GitHub URLs, missing repos, auth errors).

### New: `tests/unit/test_issue_template_assessor.py` (8 tests)

Tests for basic assessor behavior plus org-level fallback covering scenarios:
- Org-only templates (PR + issue inherited from `.github`)
- No org templates (falls back to no-op)
- No token (org check skipped)
- Non-GitHub URL (owner extraction returns None)
- Local templates alone (no org check when local suffice)
- Mixed: org PR template + local issue template

## Tests

```
$ python -m pytest tests/unit/test_github_templates.py tests/unit/test_issue_template_assessor.py -v
26 passed in 0.16s

$ python -m pytest tests/ -x -q
1248 passed, 21 skipped
```

All linters pass: `black`, `isort`, `ruff`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PR and issue templates can now be inherited from organization-level GitHub repositories as a fallback when local templates are unavailable.
  * Organization-level template checks require a configured GitHub token.

* **Tests**
  * Added comprehensive test coverage for template inheritance and assessment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->