### PR TITLE
fix: ensure pytest imports from local src/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ line_length = 88
 skip_gitignore = true
 
 [tool.pytest.ini_options]
+pythonpath = ["src"]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]


### PR DESCRIPTION
## Summary

- Adds `pythonpath = ["src"]` to `[tool.pytest.ini_options]` in `pyproject.toml`
- Ensures pytest always resolves imports from the local source tree, not a globally installed copy of agentready
- Without this, contributors who have agentready installed (via pip or an editable install in another directory) silently run tests against the wrong copy

One-line change, zero impact on contributor workflow.

This PR was created by Bill Murdock with assistance from Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment configuration to optimize testing setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->