### PR TITLE
fix: wire orphaned repomix-update.yml.j2 template and fix output paths

### DIFF
--- a/src/agentready/services/bootstrap.py
+++ b/src/agentready/services/bootstrap.py
@@ -101,6 +101,12 @@ class BootstrapGenerator:
         content = template.render()
         created.append(self._write_file(security_workflow, content, dry_run))
 
+        # Repomix update workflow
+        repomix_workflow = workflows_dir / "repomix-update.yml"
+        template = self.env.get_template("workflows/repomix-update.yml.j2")
+        content = template.render()
+        created.append(self._write_file(repomix_workflow, content, dry_run))
+
         return created
 
     def _generate_github_templates(self, dry_run: bool) -> List[Path]:

--- a/src/agentready/templates/bootstrap/workflows/repomix-update.yml.j2
+++ b/src/agentready/templates/bootstrap/workflows/repomix-update.yml.j2
@@ -1,3 +1,4 @@
+{% raw -%}
 name: Update Repomix Output
 
 on:
@@ -36,14 +37,15 @@ jobs:
 
       - name: Generate Repomix output
         run: |
-          repomix --verbose
+          mkdir -p repomix
+          repomix --verbose --output repomix/repomix-output.md
           echo "Generated Repomix output files:"
-          ls -lh repomix-output.*
+          ls -lh repomix/repomix-output.*
 
       - name: Check for changes
         id: check_changes
         run: |
-          if git diff --quiet repomix-output.*; then
+          if git diff --quiet repomix/repomix-output.*; then
             echo "changed=false" >> $GITHUB_OUTPUT
             echo "No changes detected in Repomix output"
           else
@@ -56,7 +58,7 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add repomix-output.*
+          git add repomix/repomix-output.*
           git commit -m "chore: Update Repomix repository context
 
           🤖 Generated with [Repomix](https://github.com/yamadashy/repomix)
@@ -70,7 +72,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const stats = fs.statSync('repomix-output.md');
+            const stats = fs.statSync('repomix/repomix-output.md');
             const sizeKB = (stats.size / 1024).toFixed(2);
 
             github.rest.issues.createComment({
@@ -81,7 +83,7 @@ jobs:
 
               This PR modifies repository files. The Repomix context output has been regenerated.
 
-              **Updated File**: \`repomix-output.md\` (${sizeKB} KB)
+              **Updated File**: \`repomix/repomix-output.md\` (${sizeKB} KB)
 
               The Repomix output provides AI-friendly context for the entire repository. Consider regenerating locally if you need the latest context for AI-assisted development.
 
@@ -97,7 +99,8 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           if [ "${{ steps.check_changes.outputs.changed }}" == "true" ]; then
             echo "✅ Repomix output updated successfully" >> $GITHUB_STEP_SUMMARY
-            ls -lh repomix-output.* | awk '{print "- " $9 ": " $5}' >> $GITHUB_STEP_SUMMARY
+            ls -lh repomix/repomix-output.* | awk '{print "- " $9 ": " $5}' >> $GITHUB_STEP_SUMMARY
           else
             echo "ℹ️ No changes to Repomix output" >> $GITHUB_STEP_SUMMARY
           fi
+{% endraw %}

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -70,14 +70,15 @@ class TestBootstrapGenerator:
         """Test workflow generation."""
         workflows = generator._generate_workflows(dry_run=False)
 
-        # Should generate 3 workflows
-        assert len(workflows) == 3
+        # Should generate 4 workflows
+        assert len(workflows) == 4
 
         # Check workflow files exist
         workflow_names = [w.name for w in workflows]
         assert "agentready-assessment.yml" in workflow_names
         assert "tests.yml" in workflow_names
         assert "security.yml" in workflow_names
+        assert "repomix-update.yml" in workflow_names
 
         # Verify content is valid YAML
         for workflow in workflows:
@@ -192,7 +193,7 @@ class TestBootstrapGenerator:
 
         # Check specific locations
         workflow_files = [f for f in files if "workflows" in str(f)]
-        assert len(workflow_files) == 3
+        assert len(workflow_files) == 4
 
         issue_template_files = [f for f in files if "ISSUE_TEMPLATE" in str(f)]
         assert len(issue_template_files) == 2
@@ -250,6 +251,17 @@ class TestBootstrapTemplateRendering:
             # Should not have Jinja2 control flow syntax in output
             # Note: GitHub Actions uses ${{ }} syntax which is valid and expected
             assert "{%" not in content
+
+    def test_repomix_workflow_uses_subdirectory_output(self, generator):
+        """Test that repomix workflow outputs to repomix/ subdirectory."""
+        generator.generate_all(dry_run=False)
+
+        workflow = generator.repo_path / ".github" / "workflows" / "repomix-update.yml"
+        assert workflow.exists()
+
+        content = workflow.read_text()
+        assert "repomix/repomix-output" in content
+        assert "mkdir -p repomix" in content
 
     def test_templates_render_without_errors(self, generator):
         """Test that all templates render without errors."""


### PR DESCRIPTION
## Summary
- Wire the orphaned `repomix-update.yml.j2` bootstrap template into `BootstrapGenerator._generate_workflows()` so it is generated during `agentready bootstrap`
- Fix all output path references from `repomix-output.*` (repo root) to `repomix/repomix-output.*` (subdirectory) to match what `RepomixService` expects
- Wrap template in `{% raw %}` block to prevent Jinja2 from interpreting GitHub Actions `${{ }}` expressions

## Test plan
- [x] All 20 `test_bootstrap.py` unit tests pass (including new `test_repomix_workflow_uses_subdirectory_output`)
- [x] Linters pass (black, isort, ruff)
- [x] CI passes
- [x] Run `agentready bootstrap` on multiple real repos (varying languages/sizes) and verify `repomix-update.yml` is generated under `.github/workflows/` with correct `repomix/repomix-output.*` paths
- [x] Run `agentready assess` on those same repos after bootstrap and verify the `repomix_config` assessment passes

Closes #410

*Submitted by Bill Murdock with assistance from Claude Code*

🤖 Generated with [Claude Code](https://claude.com/claude-code)