### PR TITLE
docs: flag bootstrap overwrite behavior as not yet implemented

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -397,7 +397,7 @@ class BootstrapGenerator:
 - `_render_template()` — Render Jinja2 template with context variables
 - `_get_templates_for_language()` — Map language to template files
 - `_write_file()` — Create file on disk (respects dry_run)
-- `_file_exists()` — Check for conflicts (never overwrites)
+- `_write_file()` — Write file to disk (⚠️ currently overwrites existing files, see [#449](https://github.com/ambient-code/agentready/issues/449))
 
 #### 2. Bootstrap CLI (`cli/bootstrap.py`)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -98,7 +98,7 @@ Bootstrap is AgentReady's automated infrastructure generator. One command create
 **Safe by Design**:
 
 - Use `--dry-run` to preview changes
-- Never overwrites existing files
+- Never overwrites existing files (⚠️ [not yet fully implemented](https://github.com/ambient-code/agentready/issues/449), currently only `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` are protected)
 - Review with `git status` before committing
 
 ### When to Use Bootstrap vs Assess


### PR DESCRIPTION
## Summary
- Add warning to `docs/user-guide.md` noting that the "never overwrites existing files" guarantee is not yet fully implemented (only `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` are protected)
- Fix stale `_file_exists()` reference in `docs/developer-guide.md` to reflect the actual `_write_file()` method and its current behavior
- Both warnings link to #449 for tracking the fix

## Test plan
- [ ] Verify links to #449 resolve correctly
- [ ] Docs render correctly on GitHub

Submitted by Bill Murdock with assistance from Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify current file handling behavior and limitations regarding protection from overwrites. Specifically noted that existing-file protection is not yet fully implemented and currently applies only to specific configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->