### PR TITLE
fix: treat unverifiable submitter access as warning instead of error

### DIFF
--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -155,13 +155,12 @@ jobs:
           if [ "$HOST" = "github" ]; then
             # GitHub: verify via API
             ORG_REPO=$(echo "$REPO_URL" | sed 's|git@github.com:||' | sed 's|https://github.com/||' | sed 's|\.git$||')
-            HTTP_CODE=$(gh api "/repos/$ORG_REPO/collaborators/$SUBMITTER" --silent 2>/dev/null; echo $?)
-            if [ "$HTTP_CODE" = "0" ]; then
+            if gh api "/repos/$ORG_REPO/collaborators/$SUBMITTER" --silent 2>/dev/null; then
               echo "✅ $SUBMITTER is a collaborator on $ORG_REPO"
             elif [ "$(gh api "/repos/$ORG_REPO" -q '.owner.login')" == "$SUBMITTER" ]; then
               echo "✅ $SUBMITTER is the owner of $ORG_REPO"
             else
-              echo "::warning::Cannot verify submitter access for $ORG_REPO (API returned 403). Manual review required."
+              echo "::warning::Cannot verify submitter access for $ORG_REPO (API check failed). Manual review required."
               echo "⚠️ Submitter access must be verified manually by maintainers."
             fi
           else

--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -155,13 +155,14 @@ jobs:
           if [ "$HOST" = "github" ]; then
             # GitHub: verify via API
             ORG_REPO=$(echo "$REPO_URL" | sed 's|git@github.com:||' | sed 's|https://github.com/||' | sed 's|\.git$||')
-            if gh api "/repos/$ORG_REPO/collaborators/$SUBMITTER" 2>/dev/null; then
+            HTTP_CODE=$(gh api "/repos/$ORG_REPO/collaborators/$SUBMITTER" --silent 2>/dev/null; echo $?)
+            if [ "$HTTP_CODE" = "0" ]; then
               echo "✅ $SUBMITTER is a collaborator on $ORG_REPO"
             elif [ "$(gh api "/repos/$ORG_REPO" -q '.owner.login')" == "$SUBMITTER" ]; then
               echo "✅ $SUBMITTER is the owner of $ORG_REPO"
             else
-              echo "::error::$SUBMITTER does not have commit access to $ORG_REPO"
-              exit 1
+              echo "::warning::Cannot verify submitter access for $ORG_REPO (API returned 403). Manual review required."
+              echo "⚠️ Submitter access must be verified manually by maintainers."
             fi
           else
             # Non-GitHub: cannot verify cross-platform access automatically


### PR DESCRIPTION
## Summary

- The leaderboard validation workflow's "Verify submitter has access" step calls the GitHub collaborator API, which requires admin access on the target repo. The Actions token never has this for external repos, so the check always fails with a 403, blocking legitimate submissions.
- Changed the failure path to emit a warning for manual review instead of hard-failing CI, matching the existing behavior for non-GitHub repos.

Fixes CI for #448.

## Test plan

- [ ] Verify this PR's own CI passes (no leaderboard files changed, so validate job is skipped)
- [ ] After merge, re-run CI on #448 and confirm the validate job no longer fails at the submitter access step
- [ ] Confirm the warning message appears in the workflow logs for repos where access cannot be verified

Generated with assistance from Claude Code by Bill Murdock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved submitter access verification in CI: when verification cannot be completed (including API errors like 403), the workflow now emits a clear warning and allows the case to proceed for manual maintainer review instead of failing immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->