### PR TITLE
docs: add SELinux/RHEL notice to container quick start

### DIFF
--- a/CONTAINER.md
+++ b/CONTAINER.md
@@ -22,6 +22,8 @@ podman run --rm \
 open ~/agentready-reports/report-latest.html
 ```
 
+> **RHEL / Fedora / SELinux users:** The commands above will fail with `Permission denied` or `dubious ownership` errors. See [Podman Rootless Mode](#podman-rootless-mode) for the required flags.
+
 ## Usage
 
 ### Assess AgentReady Itself

--- a/CONTAINER.md
+++ b/CONTAINER.md
@@ -13,16 +13,14 @@ mkdir -p ~/agentready-reports
 
 # Assess repository
 podman run --rm \
-  -v /path/to/repo:/repo:ro \
-  -v ~/agentready-reports:/reports \
+  -v /path/to/repo:/repo:ro,Z \
+  -v ~/agentready-reports:/reports:Z \
   ghcr.io/ambient-code/agentready:latest \
   assess /repo --output-dir /reports
 
 # Open reports
 open ~/agentready-reports/report-latest.html
 ```
-
-> **RHEL / Fedora / SELinux users:** The commands above will fail with `Permission denied` or `dubious ownership` errors. See [Podman Rootless Mode](#podman-rootless-mode) for the required flags.
 
 ## Usage
 

--- a/CONTAINER.md
+++ b/CONTAINER.md
@@ -13,8 +13,8 @@ mkdir -p ~/agentready-reports
 
 # Assess repository
 podman run --rm \
-  -v /path/to/repo:/repo:ro,Z \
-  -v ~/agentready-reports:/reports:Z \
+  -v /path/to/repo:/repo:ro,z \
+  -v ~/agentready-reports:/reports:z \
   ghcr.io/ambient-code/agentready:latest \
   assess /repo --output-dir /reports
 
@@ -35,8 +35,8 @@ mkdir -p ~/agentready-reports
 
 # Run assessment
 podman run --rm \
-  -v /tmp/agentready:/repo:ro \
-  -v ~/agentready-reports:/reports \
+  -v /tmp/agentready:/repo:ro,z \
+  -v ~/agentready-reports:/reports:z \
   ghcr.io/ambient-code/agentready:latest \
   assess /repo --output-dir /reports
 
@@ -52,22 +52,22 @@ mkdir -p ./agentready-reports
 
 # Local repository
 podman run --rm \
-  -v $(pwd):/repo:ro \
-  -v $(pwd)/agentready-reports:/reports \
+  -v $(pwd):/repo:ro,z \
+  -v $(pwd)/agentready-reports:/reports:z \
   ghcr.io/ambient-code/agentready:latest \
   assess /repo --output-dir /reports
 
 # With additional options
 podman run --rm \
-  -v $(pwd):/repo:ro \
-  -v $(pwd)/agentready-reports:/reports \
+  -v $(pwd):/repo:ro,z \
+  -v $(pwd)/agentready-reports:/reports:z \
   ghcr.io/ambient-code/agentready:latest \
   assess /repo --output-dir /reports --verbose
 
 # Exclude specific assessors
 podman run --rm \
-  -v $(pwd):/repo:ro \
-  -v $(pwd)/agentready-reports:/reports \
+  -v $(pwd):/repo:ro,z \
+  -v $(pwd)/agentready-reports:/reports:z \
   ghcr.io/ambient-code/agentready:latest \
   assess /repo --output-dir /reports -e type_annotations -e test_execution
 ```
@@ -77,8 +77,8 @@ podman run --rm \
 ```bash
 # Mount writable output directory
 podman run --rm \
-  -v /path/to/repo:/repo:ro \
-  -v $(pwd)/reports:/reports \
+  -v /path/to/repo:/repo:ro,z \
+  -v $(pwd)/reports:/reports:z \
   ghcr.io/ambient-code/agentready:latest \
   assess /repo --output-dir /reports
 
@@ -227,8 +227,8 @@ Mount a writable output directory to save reports to your host filesystem:
 ```bash
 mkdir -p ~/agentready-reports
 podman run --rm \
-  -v /repo:/repo:ro \
-  -v ~/agentready-reports:/reports \
+  -v /repo:/repo:ro,z \
+  -v ~/agentready-reports:/reports:z \
   ghcr.io/ambient-code/agentready:latest \
   assess /repo --output-dir /reports
 ```
@@ -258,8 +258,8 @@ podman run --rm \
   -e GIT_CONFIG_COUNT=1 \
   -e GIT_CONFIG_KEY_0=safe.directory \
   -e GIT_CONFIG_VALUE_0=/repo \
-  -v $(pwd):/repo:ro \
-  -v $(pwd)/agentready-reports:/reports \
+  -v $(pwd):/repo:ro,z \
+  -v $(pwd)/agentready-reports:/reports:z \
   ghcr.io/ambient-code/agentready:latest \
   assess /repo --output-dir /reports
 ```

--- a/README.md
+++ b/README.md
@@ -34,16 +34,16 @@ mkdir -p ~/agentready-reports
 # Assess AgentReady itself
 git clone https://github.com/ambient-code/agentready /tmp/agentready
 podman run --rm \
-  -v /tmp/agentready:/repo:ro,Z \
-  -v ~/agentready-reports:/reports:Z \
+  -v /tmp/agentready:/repo:ro,z \
+  -v ~/agentready-reports:/reports:z \
   ghcr.io/ambient-code/agentready:latest \
   assess /repo --output-dir /reports
 
 # Assess your repository
 # For large repos, add -i flag to confirm the size warning
 podman run --rm \
-  -v /path/to/your/repo:/repo:ro,Z \
-  -v ~/agentready-reports:/reports:Z \
+  -v /path/to/your/repo:/repo:ro,z \
+  -v ~/agentready-reports:/reports:z \
   ghcr.io/ambient-code/agentready:latest \
   assess /repo --output-dir /reports
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ podman run --rm \
 open ~/agentready-reports/report-latest.html
 ```
 
+> **RHEL / Fedora / SELinux users:** The commands above will fail on systems with SELinux enforcing. See the [Podman Rootless Mode](CONTAINER.md#podman-rootless-mode) section for required flags.
+
 [See full container documentation →](CONTAINER.md)
 
 ### Python Package

--- a/README.md
+++ b/README.md
@@ -34,24 +34,22 @@ mkdir -p ~/agentready-reports
 # Assess AgentReady itself
 git clone https://github.com/ambient-code/agentready /tmp/agentready
 podman run --rm \
-  -v /tmp/agentready:/repo:ro \
-  -v ~/agentready-reports:/reports \
+  -v /tmp/agentready:/repo:ro,Z \
+  -v ~/agentready-reports:/reports:Z \
   ghcr.io/ambient-code/agentready:latest \
   assess /repo --output-dir /reports
 
 # Assess your repository
 # For large repos, add -i flag to confirm the size warning
 podman run --rm \
-  -v /path/to/your/repo:/repo:ro \
-  -v ~/agentready-reports:/reports \
+  -v /path/to/your/repo:/repo:ro,Z \
+  -v ~/agentready-reports:/reports:Z \
   ghcr.io/ambient-code/agentready:latest \
   assess /repo --output-dir /reports
 
 # Open reports
 open ~/agentready-reports/report-latest.html
 ```
-
-> **RHEL / Fedora / SELinux users:** The commands above will fail on systems with SELinux enforcing. See the [Podman Rootless Mode](CONTAINER.md#podman-rootless-mode) section for required flags.
 
 [See full container documentation →](CONTAINER.md)
 


### PR DESCRIPTION
## Summary
- Added callout notes to Quick Start sections in both `README.md` and `CONTAINER.md` warning RHEL/Fedora/SELinux users that the default commands will fail
- Points users to the existing "Podman Rootless Mode" section which documents the required flags (`:z` labels, `--userns=keep-id`, `GIT_CONFIG_*` env vars)

## Context
Following the Quick Start container examples on a Fedora system with SELinux enforcing results in `Permission denied` and `dubious ownership` errors. The fix already exists in the Podman Rootless Mode section, but there's no indication in the Quick Start to look there — users hit a wall with no guidance.

## Test plan
- [ ] Verify the Quick Start commands still render correctly in GitHub markdown
- [ ] Confirm the anchor link `#podman-rootless-mode` resolves correctly in CONTAINER.md
- [ ] Confirm the cross-file link `CONTAINER.md#podman-rootless-mode` resolves from README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Quick Start, container setup, and troubleshooting examples updated to add SELinux relabeling labels (use :Z / :z on bind mounts) so Podman bind mounts work on SELinux-enabled systems.
  * Guidance retained for RHEL/Fedora/SELinux users about permission/ownership errors and Podman Rootless Mode configuration/workarounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->