### PR TITLE
feat: support Husky as equivalent pre-commit hook framework

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -789,10 +789,11 @@ Pre-commit hooks give immediate local feedback. They can be bypassed with `--no-
 The assessor scores on a 100-point scale:
 
 - **`.pre-commit-config.yaml` present** (60 pts): pre-commit hooks configured
+- **`.husky` directory with hook scripts** (60 pts): Husky git hooks configured (e.g., pre-commit, commit-msg)
+- **`.husky` directory without hook scripts** (10 pts): Husky directory exists but no hooks defined
 - **`.claude/settings.json` with hooks** (30 pts): Claude Code hook configuration present
-- **`.husky` directory** (10 pts): Husky git hooks configured
 
-**Pass threshold**: 60 points or higher. A `.pre-commit-config.yaml` alone is sufficient to pass.
+**Pass threshold**: 60 points or higher. Either `.pre-commit-config.yaml` or `.husky` with hook scripts is sufficient to pass.
 
 #### Remediation
 

--- a/src/agentready/assessors/testing.py
+++ b/src/agentready/assessors/testing.py
@@ -588,9 +588,19 @@ class DeterministicEnforcementAssessor(BaseAssessor):
                 score += 10.0
                 evidence.append(".claude/settings.json exists")
 
-        if husky_dir.exists():
-            score += 10.0
-            evidence.append(".husky directory found (git hooks)")
+        if husky_dir.exists() and husky_dir.is_dir():
+            hook_scripts = [
+                f.name
+                for f in husky_dir.iterdir()
+                if f.is_file() and not f.name.startswith("_")
+            ]
+            if hook_scripts:
+                score += 60.0
+                hooks_list = ", ".join(sorted(hook_scripts))
+                evidence.append(f".husky directory found with hooks: {hooks_list}")
+            else:
+                score += 10.0
+                evidence.append(".husky directory found but no hook scripts")
 
         score = min(score, 100.0)
 
@@ -634,14 +644,14 @@ class DeterministicEnforcementAssessor(BaseAssessor):
             summary="Set up deterministic enforcement with hooks and lint rules",
             steps=[
                 "Start with 2 hooks: auto-format on edit + block destructive operations",
-                "Install pre-commit framework for git hooks",
+                "Install pre-commit (Python) or Husky (Node.js) for git hooks",
                 "Configure .claude/settings.json with agent hooks for team-wide sharing",
                 "Add lint rules for import restrictions and architectural boundaries",
             ],
-            tools=["pre-commit"],
+            tools=["pre-commit", "husky"],
             commands=[
-                "pip install pre-commit",
-                "pre-commit install",
+                "pip install pre-commit && pre-commit install",
+                "npx husky init",
                 "mkdir -p .claude",
             ],
             examples=[

--- a/src/agentready/assessors/testing.py
+++ b/src/agentready/assessors/testing.py
@@ -589,11 +589,33 @@ class DeterministicEnforcementAssessor(BaseAssessor):
                 evidence.append(".claude/settings.json exists")
 
         if husky_dir.exists() and husky_dir.is_dir():
-            hook_scripts = [
-                f.name
-                for f in husky_dir.iterdir()
-                if f.is_file() and not f.name.startswith("_")
-            ]
+            valid_hook_names = {
+                "applypatch-msg",
+                "commit-msg",
+                "post-applypatch",
+                "post-checkout",
+                "post-commit",
+                "post-merge",
+                "post-rewrite",
+                "pre-applypatch",
+                "pre-auto-gc",
+                "pre-commit",
+                "pre-merge-commit",
+                "pre-push",
+                "pre-rebase",
+                "prepare-commit-msg",
+            }
+            try:
+                hook_scripts = [
+                    f.name
+                    for f in husky_dir.iterdir()
+                    if f.is_file()
+                    and not f.name.startswith("_")
+                    and f.name in valid_hook_names
+                ]
+            except OSError:
+                hook_scripts = []
+                evidence.append(".husky directory exists but could not be read")
             if hook_scripts:
                 score += 60.0
                 hooks_list = ", ".join(sorted(hook_scripts))

--- a/tests/unit/test_assessors_testing.py
+++ b/tests/unit/test_assessors_testing.py
@@ -561,6 +561,49 @@ class TestDeterministicEnforcementAssessor:
         assert finding.score >= 60.0
         assert any("pre-commit" in e.lower() for e in finding.evidence)
 
+    def test_husky_with_hooks_passes(self, tmp_path):
+        """Test that .husky directory with hook scripts passes."""
+        husky_dir = tmp_path / ".husky"
+        husky_dir.mkdir()
+        (husky_dir / "pre-commit").write_text("#!/bin/sh\nnpx lint-staged\n")
+        (husky_dir / "commit-msg").write_text("#!/bin/sh\nnpx commitlint --edit $1\n")
+
+        repo = _make_repo(tmp_path)
+        assessor = DeterministicEnforcementAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.status == "pass"
+        assert finding.score >= 60.0
+        assert any(".husky" in e for e in finding.evidence)
+        assert any("pre-commit" in e for e in finding.evidence)
+        assert any("commit-msg" in e for e in finding.evidence)
+
+    def test_husky_empty_dir_does_not_pass(self, tmp_path):
+        """Test that .husky directory without hook scripts only gives partial score."""
+        husky_dir = tmp_path / ".husky"
+        husky_dir.mkdir()
+
+        repo = _make_repo(tmp_path)
+        assessor = DeterministicEnforcementAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.status == "fail"
+        assert finding.score == 10.0
+        assert any("no hook scripts" in e for e in finding.evidence)
+
+    def test_husky_ignores_underscore_files(self, tmp_path):
+        """Test that files starting with _ (like _/husky.sh) are ignored."""
+        husky_dir = tmp_path / ".husky"
+        husky_dir.mkdir()
+        (husky_dir / "_").mkdir()
+        (husky_dir / "pre-commit").write_text("#!/bin/sh\nnpx lint-staged\n")
+
+        repo = _make_repo(tmp_path)
+        assessor = DeterministicEnforcementAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.score >= 60.0
+
     def test_no_config_fails(self, tmp_path):
         """Test fail when no enforcement config exists."""
         repo = _make_repo(tmp_path)

--- a/tests/unit/test_assessors_testing.py
+++ b/tests/unit/test_assessors_testing.py
@@ -592,10 +592,13 @@ class TestDeterministicEnforcementAssessor:
         assert any("no hook scripts" in e for e in finding.evidence)
 
     def test_husky_ignores_underscore_files(self, tmp_path):
-        """Test that files starting with _ (like _/husky.sh) are ignored."""
+        """Test that underscore-prefixed files and non-hook files are ignored."""
         husky_dir = tmp_path / ".husky"
         husky_dir.mkdir()
         (husky_dir / "_").mkdir()
+        (husky_dir / "_local").write_text("#!/bin/sh\necho local\n")
+        (husky_dir / ".gitignore").write_text("_\n")
+        (husky_dir / "README.md").write_text("# Hooks\n")
         (husky_dir / "pre-commit").write_text("#!/bin/sh\nnpx lint-staged\n")
 
         repo = _make_repo(tmp_path)
@@ -603,6 +606,10 @@ class TestDeterministicEnforcementAssessor:
         finding = assessor.assess(repo)
 
         assert finding.score >= 60.0
+        evidence_str = " ".join(finding.evidence)
+        assert "_local" not in evidence_str
+        assert ".gitignore" not in evidence_str
+        assert "README.md" not in evidence_str
 
     def test_no_config_fails(self, tmp_path):
         """Test fail when no enforcement config exists."""


### PR DESCRIPTION
## Summary

Closes #433

- `.husky/` with hook scripts now scores 60 pts (same as `.pre-commit-config.yaml`), so JS/TS/Java projects using Husky can pass the deterministic enforcement attribute
- Empty `.husky/` directory (no hook scripts) stays at 10 pts
- Underscore-prefixed files (e.g. `_/husky.sh`) are correctly ignored
- Remediation guidance updated to list Husky as an alternative (`npx husky init`)
- `docs/attributes.md` updated with new scoring breakdown

## Test plan

- [x] 3 new unit tests: Husky with hooks passes, empty dir doesn't pass, underscore files ignored
- [x] All 1104 existing unit tests pass
- [x] Linting clean (black, isort, ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git hooks assessment to verify actual hook scripts and apply different scores for directories with or without valid hooks.

* **Documentation**
  * Updated deterministic enforcement docs: clarified scoring, pass conditions, and added Husky setup guidance.

* **Tests**
  * Added unit tests covering hook-directory scenarios (with hooks, empty, and ignored files).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->