### PR TITLE
fix: correct broken Tier Definitions link in Markdown report (#468)

### DIFF
--- a/src/agentready/reporters/markdown.py
+++ b/src/agentready/reporters/markdown.py
@@ -98,7 +98,7 @@ class MarkdownReporter(BaseReporter):
 
 | Metric | Value |
 |--------|-------|
-| **Overall Score** | **{assessment.overall_score:.1f}/100** {cert_emoji} **{assessment.certification_level}** ([Tier Definitions](https://agentready.dev/attributes.html#tier-system)) |
+| **Overall Score** | **{assessment.overall_score:.1f}/100** {cert_emoji} **{assessment.certification_level}** ([Tier Definitions](https://ambient-code.github.io/agentready/attributes.html#tier-system)) |
 | **Attributes Assessed** | {assessment.attributes_assessed}/{assessment.attributes_total} |
 | **Attributes Not Assessed** | {assessment.attributes_not_assessed} |
 | **Assessment Duration** | {assessment.duration_seconds:.1f}s |


### PR DESCRIPTION
The link pointed to agentready.dev which is an unrelated site. Updated to the project's actual GitHub Pages docs URL.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues

<!-- Link related issues here using #issue_number -->

Fixes #468
Relates to #

## Changes Made

<!-- Detailed list of changes made in this PR -->

- Update URL to the project's GitHub Pages docs site: https://ambient-code.github.io/agentready/attributes.html#tier-system
-
-

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests pass (`pytest`)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] No new warnings or errors

## Checklist

- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Tier Definitions hyperlink in generated Markdown reports to direct users to the correct documentation location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->