### PR TITLE
feat: add test-assess skill for validating assessors against real repos

### DIFF
--- a/.claude/skills/test-assess/SKILL.md
+++ b/.claude/skills/test-assess/SKILL.md
@@ -1,0 +1,94 @@
+---
+description: >
+  Test agentready assess against real GitHub repositories to validate assessor
+  changes. Selects repos relevant to the change being tested, clones them to a
+  temp directory, runs the local checkout's assessor, reports results and output
+  locations, then cleans up. Use when testing a new or modified assessor, verifying
+  a PR's scoring behavior, or validating that a change works on real-world repos.
+argument-hint: "[description of what to test]"
+allowed-tools:
+  - Bash(git clone *)
+  - Bash(rm -rf /tmp/agentready-test-*)
+  - Bash(PYTHONPATH=src python -m agentready *)
+---
+
+## Test agentready assess on real repositories
+
+You are testing the agentready assessment tool against real GitHub repositories
+to validate that a change works correctly.
+
+### 1. Determine what to test
+
+The user will describe what assessor behavior they want to validate (e.g., "test
+Husky detection", "verify the new CI gates assessor"). If the description is
+unclear, ask a brief clarifying question.
+
+### 2. Ensure the code under test is checked out
+
+Check which branch is currently active. If the change being tested is on a
+different branch or PR, check it out first. If it is a PR, use
+`gh pr checkout <number>`.
+
+### 3. Select repositories
+
+Search GitHub for repositories that are relevant to the feature being tested.
+For example, if testing Husky hook detection, find repos that use Husky.
+
+**How many repos:**
+- Small or targeted changes: at least 1 repo
+- Larger or riskier changes: 3 to 5 repos
+
+**Selection criteria (in priority order):**
+1. **Relevance**: repos must exercise the specific behavior being tested.
+   This is the most important criterion.
+2. **Variety of maturity**: when possible, mix large popular projects with
+   smaller or newer ones. But never sacrifice relevance for variety.
+
+Use `gh search repos`, `gh api`, or `gh search code` to find candidates.
+Briefly confirm your repo selections with the user before cloning.
+
+### 4. Clone repos to a temp directory
+
+Create a unique temp directory for this test run:
+
+```
+TESTDIR=$(mktemp -d /tmp/agentready-test-XXXXXX)
+```
+
+Shallow clone each repo into that directory:
+
+```
+git clone --depth 1 <repo-url> $TESTDIR/<repo-name>
+```
+
+### 5. Run assessments
+
+Run each assessment using the local checkout, not the globally installed package:
+
+```
+yes | PYTHONPATH=src python -m agentready assess $TESTDIR/<repo-name>
+```
+
+The `yes |` prefix auto-confirms the large-repo prompt if it appears.
+
+### 6. Report results
+
+After each assessment completes, report to the user:
+- The repo name and the overall score/certification level
+- The specific finding(s) relevant to what is being tested, including
+  status, score, and evidence
+- The exact paths to the JSON, HTML, and Markdown reports so the user can
+  inspect them
+
+Summarize all results in a table at the end if multiple repos were tested.
+
+### 7. Clean up
+
+After the user has seen the results, delete the temp directory:
+
+```
+rm -rf $TESTDIR
+```
+
+Tell the user the cleanup is done. If any repo's reports are worth preserving,
+ask before deleting.

--- a/.claude/skills/test-assess/SKILL.md
+++ b/.claude/skills/test-assess/SKILL.md
@@ -7,6 +7,7 @@ description: >
   a PR's scoring behavior, or validating that a change works on real-world repos.
 argument-hint: "[description of what to test]"
 allowed-tools:
+  - Bash(mktemp -d /tmp/agentready-test-*)
   - Bash(git clone *)
   - Bash(rm -rf /tmp/agentready-test-*)
   - Bash(PYTHONPATH=src python -m agentready *)
@@ -51,13 +52,13 @@ Briefly confirm your repo selections with the user before cloning.
 
 Create a unique temp directory for this test run:
 
-```
+```bash
 TESTDIR=$(mktemp -d /tmp/agentready-test-XXXXXX)
 ```
 
 Shallow clone each repo into that directory:
 
-```
+```bash
 git clone --depth 1 <repo-url> $TESTDIR/<repo-name>
 ```
 
@@ -65,7 +66,7 @@ git clone --depth 1 <repo-url> $TESTDIR/<repo-name>
 
 Run each assessment using the local checkout, not the globally installed package:
 
-```
+```bash
 yes | PYTHONPATH=src python -m agentready assess $TESTDIR/<repo-name>
 ```
 
@@ -86,7 +87,7 @@ Summarize all results in a table at the end if multiple repos were tested.
 
 After the user has seen the results, delete the temp directory:
 
-```
+```bash
 rm -rf $TESTDIR
 ```
 

--- a/.claude/skills/test-assess/SKILL.md
+++ b/.claude/skills/test-assess/SKILL.md
@@ -9,11 +9,13 @@ argument-hint: "[description of what to test]"
 allowed-tools:
   - Bash(mktemp -d /tmp/agentready-test-*)
   - Bash(git clone *)
+  - Bash(gh *)
+  - Bash(yes *)
   - Bash(rm -rf /tmp/agentready-test-*)
   - Bash(PYTHONPATH=src python -m agentready *)
 ---
 
-## Test agentready assess on real repositories
+# Test agentready assess on real repositories
 
 You are testing the agentready assessment tool against real GitHub repositories
 to validate that a change works correctly.


### PR DESCRIPTION
## Summary
- Adds a `.claude/skills/test-assess/` skill that validates assessor changes by running them against real GitHub repositories
- Recovered from a previous session where it was created but never committed

## What it does
1. Finds relevant GitHub repos for the feature being tested (e.g., repos using Husky for testing Husky detection)
2. Clones them to a temp directory
3. Runs the local checkout's assessor via `PYTHONPATH=src python -m agentready assess`
4. Reports the specific findings, scores, and report paths
5. Cleans up

## Test plan
- [x] Skill file follows the SKILL.md format with frontmatter
- [x] Invoke with `/test-assess` and verify it works end-to-end

Posted by Bill Murdock with assistance from Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive skill guide for end-to-end testing of the assessor against real repositories. Covers metadata, selecting branch/PR and repositories, shallow cloning into temporary locations, running automated assessments with confirmation, reporting per-repo scores and findings with JSON/HTML/Markdown outputs, and cleanup options for temporary artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->