### PR TITLE
feat: enforcement and intent assessor improvements (ADR A.5, A.8)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,28 @@
 {
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "black --quiet \"$CLAUDE_FILE_PATH\" 2>/dev/null; isort --quiet \"$CLAUDE_FILE_PATH\" 2>/dev/null; true"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo \"$CLAUDE_TOOL_INPUT\" | grep -qE 'rm -rf|DROP TABLE|--force' && echo 'BLOCK: destructive command' && exit 1 || true"
+          }
+        ]
+      }
+    ]
+  },
   "permissions": {
     "allow": [
       "Skill(frontend-design:frontend-design)",

--- a/.claude/skills/test-assess/SKILL.md
+++ b/.claude/skills/test-assess/SKILL.md
@@ -11,7 +11,8 @@ allowed-tools:
   - Bash(git clone *)
   - Bash(gh *)
   - Bash(yes *)
-  - Bash(rm -rf /tmp/agentready-test-*)
+  - Bash(find /tmp/agentready-test-* -delete)
+  - Bash(rmdir /tmp/agentready-test-*)
   - Bash(PYTHONPATH=src python -m agentready *)
 ---
 
@@ -90,7 +91,7 @@ Summarize all results in a table at the end if multiple repos were tested.
 After the user has seen the results, delete the temp directory:
 
 ```bash
-rm -rf $TESTDIR
+find $TESTDIR -delete
 ```
 
 Tell the user the cleanup is done. If any repo's reports are worth preserving,

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,7 @@ docs/_site/
 
 # Claude
 .claude/settings.local.json
+
+# Other AI agent tooling
+.agents/
+.codex/

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -794,18 +794,19 @@ Automated code quality checks before commits (pre-commit hooks) and in CI/CD pip
 
 #### Why It Matters
 
-Pre-commit hooks give immediate local feedback. They can be bypassed with `--no-verify`, which is why CI matters too — but for agent-generated commits that go through a normal PR flow, hooks are the first line of defense. Catching a lint error before a commit beats catching it in CI review.
+Agent hooks (`.claude/settings.json`) are deterministic for agent workflows: they always execute and cannot be bypassed. Git hooks (pre-commit, Husky) provide local feedback but can be bypassed with `--no-verify`. Both matter, but agent hooks score higher because they are the primary enforcement mechanism for AI-assisted development.
 
 #### Measurable Criteria
 
 The assessor scores on a 100-point scale:
 
-- **`.pre-commit-config.yaml` present** (60 pts): pre-commit hooks configured
-- **`.husky` directory with hook scripts** (60 pts): Husky git hooks configured (e.g., pre-commit, commit-msg)
+- **`.claude/settings.json` with hooks** (60 pts): Deterministic agent hooks configured (cannot be bypassed)
+- **`.pre-commit-config.yaml` present** (40 pts): Pre-commit git hooks configured (bypassable with `--no-verify`)
+- **`.husky` directory with hook scripts** (40 pts): Husky git hooks configured (bypassable with `--no-verify`)
+- **`.claude/settings.json` without hooks** (10 pts): Agent settings present but no hooks defined
 - **`.husky` directory without hook scripts** (10 pts): Husky directory exists but no hooks defined
-- **`.claude/settings.json` with hooks** (30 pts): Claude Code hook configuration present
 
-**Pass threshold**: 60 points or higher. Either `.pre-commit-config.yaml` or `.husky` with hook scripts is sufficient to pass.
+**Pass threshold**: 40 points or higher. Any single enforcement mechanism (agent hooks, pre-commit, or Husky with scripts) is sufficient to pass.
 
 #### Remediation
 
@@ -1032,7 +1033,7 @@ setup:
 **File Size Limits** (`file_size_limits`, 3%) — Files under threshold to keep context manageable
 **Separation of Concerns** (`separation_of_concerns`, 3%) — Clean module boundaries and single-responsibility
 **Pattern References** (`pattern_references`, 3%) — Documented patterns for common changes. Skills scoring is tiered: 1-2 SKILL.md files earn partial credit (30 pts), 3+ earn full credit (60 pts). Context files >150 lines without skills trigger a warning
-**Design Intent Documentation** (`design_intent`, 3%) — Preconditions, invariants, and rationale in design docs (moved from T3)
+**Design Intent Documentation** (`design_intent`, 3%) — Preconditions, invariants, and rationale in design docs (moved from T3). Enforcement bonus: advisory rules in AGENTS.md requiring design doc updates (+10 pts), or deterministic enforcement via hooks/skills (+15 pts). The higher of the two is awarded, not both
 
 *Full details for each attribute available in the [research document](https://github.com/ambient-code/agentready/blob/main/RESEARCH_REPORT.md).*
 

--- a/src/agentready/assessors/patterns.py
+++ b/src/agentready/assessors/patterns.py
@@ -352,7 +352,11 @@ class DesignIntentAssessor(BaseAssessor):
                 settings = json.loads(settings_path.read_text(encoding="utf-8"))
                 hooks = settings.get("hooks", {})
                 hooks_str = json.dumps(hooks).lower()
-                if hooks and doc_ref_pattern.search(hooks_str):
+                if (
+                    hooks
+                    and doc_ref_pattern.search(hooks_str)
+                    and enforcement_verb_pattern.search(hooks_str)
+                ):
                     deterministic_score = 15.0
                     deterministic_evidence.append(
                         ".claude/settings.json hooks reference design docs (deterministic enforcement)"

--- a/src/agentready/assessors/patterns.py
+++ b/src/agentready/assessors/patterns.py
@@ -290,6 +290,13 @@ class DesignIntentAssessor(BaseAssessor):
                     evidence.append(f"Design intent language found in {filename}")
                     break
 
+        enforcement_pts, enforcement_evidence = self._check_design_enforcement(
+            repository
+        )
+        if enforcement_pts > 0:
+            score += enforcement_pts
+            evidence.extend(enforcement_evidence)
+
         score = min(score, 100.0)
 
         if score >= 50:
@@ -315,6 +322,95 @@ class DesignIntentAssessor(BaseAssessor):
                 error_message=None,
             )
 
+    def _check_design_enforcement(
+        self, repository: Repository
+    ) -> tuple[float, list[str]]:
+        """Check for enforcement of design doc updates alongside code changes.
+
+        Advisory enforcement (10 pts): AGENTS.md/CLAUDE.md rules requiring
+        design doc updates with architectural changes.
+        Deterministic enforcement (15 pts): Hooks or skills that check for
+        design doc updates. Awards the higher of the two, not both.
+        """
+        import json
+
+        doc_ref_pattern = re.compile(
+            r"design\s+doc|docs/design|architecture\s+doc|\.adr|design\s+document",
+            re.IGNORECASE,
+        )
+        enforcement_verb_pattern = re.compile(
+            r"update|review|create|maintain|must|required|ensure|check",
+            re.IGNORECASE,
+        )
+
+        deterministic_score = 0.0
+        deterministic_evidence = []
+
+        settings_path = repository.path / ".claude" / "settings.json"
+        if settings_path.exists():
+            try:
+                settings = json.loads(settings_path.read_text(encoding="utf-8"))
+                hooks = settings.get("hooks", {})
+                hooks_str = json.dumps(hooks).lower()
+                if hooks and doc_ref_pattern.search(hooks_str):
+                    deterministic_score = 15.0
+                    deterministic_evidence.append(
+                        ".claude/settings.json hooks reference design docs (deterministic enforcement)"
+                    )
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        if deterministic_score == 0:
+            skills_dir = repository.path / ".claude" / "skills"
+            if skills_dir.exists() and skills_dir.is_dir():
+                try:
+                    for skill_dir in skills_dir.iterdir():
+                        if not skill_dir.is_dir():
+                            continue
+                        skill_md = skill_dir / "SKILL.md"
+                        if not skill_md.exists():
+                            continue
+                        try:
+                            content = skill_md.read_text(encoding="utf-8")
+                            if doc_ref_pattern.search(
+                                content
+                            ) and enforcement_verb_pattern.search(content):
+                                deterministic_score = 15.0
+                                deterministic_evidence.append(
+                                    f".claude/skills/{skill_dir.name}/ references design doc enforcement (deterministic)"
+                                )
+                                break
+                        except (OSError, UnicodeDecodeError):
+                            continue
+                except OSError:
+                    pass
+
+        if deterministic_score > 0:
+            return deterministic_score, deterministic_evidence
+
+        advisory_score = 0.0
+        advisory_evidence = []
+        context_files = ["AGENTS.md", "CLAUDE.md", ".claude/CLAUDE.md"]
+        for filename in context_files:
+            filepath = repository.path / filename
+            if not filepath.exists():
+                continue
+            try:
+                content = filepath.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+
+            if doc_ref_pattern.search(content) and enforcement_verb_pattern.search(
+                content
+            ):
+                advisory_score = 10.0
+                advisory_evidence.append(
+                    f"{filename} contains design doc update rules (advisory enforcement)"
+                )
+                break
+
+        return advisory_score, advisory_evidence
+
     def _create_remediation(self) -> Remediation:
         return Remediation(
             summary="Document design intent: preconditions, invariants, and rationale",
@@ -323,11 +419,14 @@ class DesignIntentAssessor(BaseAssessor):
                 "For each critical module, document preconditions, invariants, and rationale",
                 "Use an AI agent to reverse-engineer initial design docs from code, then enrich with intent",
                 "Reference design docs from CLAUDE.md/AGENTS.md",
+                "Add a rule to AGENTS.md requiring design doc updates with architectural changes",
+                "For stronger enforcement, add a hook or skill that checks for design doc updates",
             ],
             tools=[],
             commands=["mkdir -p docs/design"],
             examples=[
                 "# docs/design/event-system.md\n## Invariants\n- Event log is append-only; never mutate or delete entries\n- Events are processed exactly-once via idempotency keys\n\n## Preconditions\n- Auth middleware must validate token before event handlers run\n\n## Rationale\n- Polling instead of webhooks: upstream API has 5s delivery SLA, too slow for our use case",
+                "# AGENTS.md - Advisory enforcement\n## Design Documentation\nWhen modifying component boundaries, data flows, or API contracts,\nreview and update the corresponding design doc in docs/design/.",
             ],
             citations=[
                 Citation(
@@ -335,6 +434,12 @@ class DesignIntentAssessor(BaseAssessor):
                     title="Repository Scaffolding for AI Coding Agents, Section 2.3",
                     url="",
                     relevance="Agents cannot infer design intent from code alone",
+                ),
+                Citation(
+                    source="Red Hat",
+                    title="Repository Scaffolding for AI Coding Agents, Section 2.3 Practice C",
+                    url="",
+                    relevance="Enforce design doc updates as part of architectural changes",
                 ),
             ],
         )

--- a/src/agentready/assessors/testing.py
+++ b/src/agentready/assessors/testing.py
@@ -799,7 +799,11 @@ class DeterministicEnforcementAssessor(BaseAssessor):
                 import json
 
                 content = json.loads(claude_settings.read_text())
-                if "hooks" in content:
+                hooks = content.get("hooks")
+                has_configured_hooks = isinstance(hooks, dict) and any(
+                    isinstance(entries, list) and entries for entries in hooks.values()
+                )
+                if has_configured_hooks:
                     score += 60.0
                     evidence.append(
                         ".claude/settings.json has hooks configured (deterministic agent hooks)"
@@ -908,7 +912,12 @@ class DeterministicEnforcementAssessor(BaseAssessor):
     "PostToolUse": [
       {
         "matcher": "Edit|Write",
-        "command": "npx prettier --write $CLAUDE_FILE_PATH 2>/dev/null || true"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx prettier --write $CLAUDE_FILE_PATH 2>/dev/null || true"
+          }
+        ]
       }
     ]
   }

--- a/src/agentready/assessors/testing.py
+++ b/src/agentready/assessors/testing.py
@@ -791,8 +791,8 @@ class DeterministicEnforcementAssessor(BaseAssessor):
         score = 0.0
 
         if precommit_config.exists():
-            score += 60.0
-            evidence.append(".pre-commit-config.yaml found (pre-commit hooks)")
+            score += 40.0
+            evidence.append(".pre-commit-config.yaml found (git hooks, bypassable)")
 
         if claude_settings.exists():
             try:
@@ -800,9 +800,9 @@ class DeterministicEnforcementAssessor(BaseAssessor):
 
                 content = json.loads(claude_settings.read_text())
                 if "hooks" in content:
-                    score += 30.0
+                    score += 60.0
                     evidence.append(
-                        ".claude/settings.json has hooks configured (agent hooks)"
+                        ".claude/settings.json has hooks configured (deterministic agent hooks)"
                     )
                 else:
                     score += 10.0
@@ -840,16 +840,18 @@ class DeterministicEnforcementAssessor(BaseAssessor):
                 hook_scripts = []
                 evidence.append(".husky directory exists but could not be read")
             if hook_scripts:
-                score += 60.0
+                score += 40.0
                 hooks_list = ", ".join(sorted(hook_scripts))
-                evidence.append(f".husky directory found with hooks: {hooks_list}")
+                evidence.append(
+                    f".husky directory found with hooks: {hooks_list} (git hooks, bypassable)"
+                )
             else:
                 score += 10.0
                 evidence.append(".husky directory found but no hook scripts")
 
         score = min(score, 100.0)
 
-        if score >= 60:
+        if score >= 40:
             return Finding(
                 attribute=self.attribute,
                 status="pass",
@@ -888,9 +890,9 @@ class DeterministicEnforcementAssessor(BaseAssessor):
         return Remediation(
             summary="Set up deterministic enforcement with hooks and lint rules",
             steps=[
+                "Configure .claude/settings.json with agent hooks (deterministic, cannot be bypassed)",
                 "Start with 2 hooks: auto-format on edit + block destructive operations",
-                "Install pre-commit (Python) or Husky (Node.js) for git hooks",
-                "Configure .claude/settings.json with agent hooks for team-wide sharing",
+                "Optionally add pre-commit (Python) or Husky (Node.js) for git hooks",
                 "Add lint rules for import restrictions and architectural boundaries",
             ],
             tools=["pre-commit", "husky"],

--- a/tests/unit/test_assessors_patterns.py
+++ b/tests/unit/test_assessors_patterns.py
@@ -424,6 +424,152 @@ class TestDesignIntentAssessor:
 
         assert finding.score >= 30.0
 
+    def test_advisory_enforcement_bonus(self, tmp_path):
+        """Test that AGENTS.md with design doc update rules adds 10 pts."""
+        design_dir = tmp_path / "docs" / "design"
+        design_dir.mkdir(parents=True)
+        (design_dir / "overview.md").write_text(
+            "# Design\n## Invariants\n- Data is append-only\n"
+        )
+        agents_md = tmp_path / "AGENTS.md"
+        agents_md.write_text(
+            "## Design Documentation\n"
+            "When modifying architecture, update the corresponding design doc "
+            "in docs/design/.\n"
+        )
+
+        repo = _make_repo(tmp_path)
+        assessor = DesignIntentAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.score >= 60.0  # 50 (dir) + 10 (advisory)
+        assert any("advisory enforcement" in e.lower() for e in finding.evidence)
+
+    def test_deterministic_enforcement_bonus(self, tmp_path):
+        """Test that .claude/settings.json hooks referencing design docs add 15 pts."""
+        design_dir = tmp_path / "docs" / "design"
+        design_dir.mkdir(parents=True)
+        (design_dir / "overview.md").write_text(
+            "# Design\n## Invariants\n- Data is append-only\n"
+        )
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text(
+            '{"hooks": {"PreToolUse": [{"matcher": "Bash",'
+            ' "command": "check-design-doc-update.sh"}],'
+            ' "design_doc_path": "docs/design"}}'
+        )
+
+        repo = _make_repo(tmp_path)
+        assessor = DesignIntentAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.score >= 65.0  # 50 (dir) + 15 (deterministic)
+        assert any("deterministic" in e.lower() for e in finding.evidence)
+
+    def test_deterministic_supersedes_advisory(self, tmp_path):
+        """Test that deterministic enforcement (15 pts) takes precedence over advisory (10 pts)."""
+        design_dir = tmp_path / "docs" / "design"
+        design_dir.mkdir(parents=True)
+        (design_dir / "overview.md").write_text(
+            "# Design\n## Invariants\n- Data is append-only\n"
+        )
+        agents_md = tmp_path / "AGENTS.md"
+        agents_md.write_text(
+            "When modifying architecture, review the design doc in docs/design/.\n"
+        )
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text(
+            '{"hooks": {"PreToolUse": [{"matcher": "Bash",'
+            ' "command": "check-design-doc.sh"}],'
+            ' "design_doc_path": "docs/design"}}'
+        )
+
+        repo = _make_repo(tmp_path)
+        assessor = DesignIntentAssessor()
+        finding = assessor.assess(repo)
+
+        # 50 (dir with intent) + 15 (deterministic, supersedes advisory 10)
+        assert finding.score == 65.0
+        assert any("deterministic" in e.lower() for e in finding.evidence)
+        assert not any("advisory" in e.lower() for e in finding.evidence)
+
+    def test_enforcement_with_design_dir_scores_higher(self, tmp_path):
+        """Test that design dir + enforcement scores higher than dir alone."""
+        design_dir = tmp_path / "docs" / "design"
+        design_dir.mkdir(parents=True)
+        (design_dir / "overview.md").write_text(
+            "# Design\n## Invariants\n- Data is append-only\n"
+        )
+
+        repo = _make_repo(tmp_path)
+        assessor = DesignIntentAssessor()
+        baseline = assessor.assess(repo)
+
+        agents_md = tmp_path / "AGENTS.md"
+        agents_md.write_text(
+            "When changing architecture, update the design doc in docs/design/.\n"
+        )
+        repo2 = _make_repo(tmp_path)
+        with_enforcement = assessor.assess(repo2)
+
+        assert with_enforcement.score > baseline.score
+
+    def test_skill_based_enforcement(self, tmp_path):
+        """Test that a skill referencing design doc review triggers deterministic bonus."""
+        design_dir = tmp_path / "docs" / "design"
+        design_dir.mkdir(parents=True)
+        (design_dir / "overview.md").write_text(
+            "# Design\n## Invariants\n- Data is append-only\n"
+        )
+        skill_dir = tmp_path / ".claude" / "skills" / "design-review"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "# Design Review Skill\n"
+            "Review and update the design doc in docs/design/ "
+            "when architectural changes are detected.\n"
+        )
+
+        repo = _make_repo(tmp_path)
+        assessor = DesignIntentAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.score >= 65.0  # 50 (dir) + 15 (deterministic via skill)
+        assert any("deterministic" in e.lower() for e in finding.evidence)
+
+    def test_no_enforcement_no_bonus(self, tmp_path):
+        """Test that AGENTS.md without enforcement language gives no bonus."""
+        design_dir = tmp_path / "docs" / "design"
+        design_dir.mkdir(parents=True)
+        (design_dir / "overview.md").write_text(
+            "# Design\n## Invariants\n- Data is append-only\n"
+        )
+        agents_md = tmp_path / "AGENTS.md"
+        agents_md.write_text("# Agent Guide\nFollow the coding standards.\n")
+
+        repo = _make_repo(tmp_path)
+        assessor = DesignIntentAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.score == 50.0  # dir only, no enforcement bonus
+
+    def test_enforcement_without_design_docs(self, tmp_path):
+        """Test enforcement bonus applies even without design directory."""
+        agents_md = tmp_path / "AGENTS.md"
+        agents_md.write_text(
+            "When modifying architecture, create a design doc in docs/design/.\n"
+        )
+
+        repo = _make_repo(tmp_path)
+        assessor = DesignIntentAssessor()
+        finding = assessor.assess(repo)
+
+        # 0 (no dir) + 10 (advisory) = 10, still fail
+        assert finding.status == "fail"
+        assert finding.score == 10.0
+        assert any("advisory enforcement" in e.lower() for e in finding.evidence)
+
 
 class TestProgressiveDisclosureAssessor:
     """Test ProgressiveDisclosureAssessor."""

--- a/tests/unit/test_assessors_patterns.py
+++ b/tests/unit/test_assessors_patterns.py
@@ -467,6 +467,27 @@ class TestDesignIntentAssessor:
         assert finding.score >= 65.0  # 50 (dir) + 15 (deterministic)
         assert any("deterministic" in e.lower() for e in finding.evidence)
 
+    def test_hooks_mentioning_design_without_enforcement_no_bonus(self, tmp_path):
+        """Test that hooks referencing design docs without enforcement verbs get no bonus."""
+        design_dir = tmp_path / "docs" / "design"
+        design_dir.mkdir(parents=True)
+        (design_dir / "overview.md").write_text(
+            "# Design\n## Invariants\n- Data is append-only\n"
+        )
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text(
+            '{"hooks": {"PostToolUse": [{"matcher": "Edit",'
+            ' "hooks": [{"type": "command", "command": "echo docs/design"}]}]}}'
+        )
+
+        repo = _make_repo(tmp_path)
+        assessor = DesignIntentAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.score == 50.0  # dir only, no enforcement bonus
+        assert not any("deterministic" in e.lower() for e in finding.evidence)
+
     def test_deterministic_supersedes_advisory(self, tmp_path):
         """Test that deterministic enforcement (15 pts) takes precedence over advisory (10 pts)."""
         design_dir = tmp_path / "docs" / "design"

--- a/tests/unit/test_assessors_testing.py
+++ b/tests/unit/test_assessors_testing.py
@@ -900,7 +900,7 @@ class TestDeterministicEnforcementAssessor:
         assert assessor.attribute.default_weight == 0.03
 
     def test_pre_commit_config_passes(self, tmp_path):
-        """Test that .pre-commit-config.yaml is detected."""
+        """Test that .pre-commit-config.yaml is detected and passes at threshold 40."""
         (tmp_path / ".pre-commit-config.yaml").write_text(
             "repos:\n  - repo: https://github.com/pre-commit/pre-commit-hooks\n"
         )
@@ -909,11 +909,12 @@ class TestDeterministicEnforcementAssessor:
         assessor = DeterministicEnforcementAssessor()
         finding = assessor.assess(repo)
 
-        assert finding.score >= 60.0
+        assert finding.status == "pass"
+        assert finding.score == 40.0
         assert any("pre-commit" in e.lower() for e in finding.evidence)
 
     def test_husky_with_hooks_passes(self, tmp_path):
-        """Test that .husky directory with hook scripts passes."""
+        """Test that .husky directory with hook scripts passes at threshold 40."""
         husky_dir = tmp_path / ".husky"
         husky_dir.mkdir()
         (husky_dir / "pre-commit").write_text("#!/bin/sh\nnpx lint-staged\n")
@@ -924,7 +925,7 @@ class TestDeterministicEnforcementAssessor:
         finding = assessor.assess(repo)
 
         assert finding.status == "pass"
-        assert finding.score >= 60.0
+        assert finding.score == 40.0
         assert any(".husky" in e for e in finding.evidence)
         assert any("pre-commit" in e for e in finding.evidence)
         assert any("commit-msg" in e for e in finding.evidence)
@@ -956,7 +957,7 @@ class TestDeterministicEnforcementAssessor:
         assessor = DeterministicEnforcementAssessor()
         finding = assessor.assess(repo)
 
-        assert finding.score >= 60.0
+        assert finding.score == 40.0
         evidence_str = " ".join(finding.evidence)
         assert "_local" not in evidence_str
         assert ".gitignore" not in evidence_str
@@ -971,3 +972,67 @@ class TestDeterministicEnforcementAssessor:
 
         assert finding.status == "fail"
         assert finding.score == 0.0
+
+    def test_agent_hooks_score_higher_than_precommit(self, tmp_path):
+        """Test that agent hooks (60 pts) score higher than pre-commit (40 pts)."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text(
+            '{"hooks": {"PostToolUse": [{"matcher": "Edit", "command": "echo ok"}]}}'
+        )
+
+        repo = _make_repo(tmp_path)
+        assessor = DeterministicEnforcementAssessor()
+        agent_finding = assessor.assess(repo)
+
+        (tmp_path / ".pre-commit-config.yaml").write_text("repos: []\n")
+        precommit_repo = _make_repo(tmp_path)
+        precommit_finding = assessor.assess(precommit_repo)
+
+        assert agent_finding.score == 60.0
+        assert precommit_finding.score > 60.0  # 40 + 60 from agent hooks
+
+    def test_claude_settings_with_hooks_passes(self, tmp_path):
+        """Test that .claude/settings.json with hooks alone passes."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text(
+            '{"hooks": {"PostToolUse": [{"matcher": "Edit", "command": "echo ok"}]}}'
+        )
+
+        repo = _make_repo(tmp_path)
+        assessor = DeterministicEnforcementAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.status == "pass"
+        assert finding.score == 60.0
+        assert any("deterministic" in e.lower() for e in finding.evidence)
+
+    def test_claude_settings_without_hooks_does_not_pass(self, tmp_path):
+        """Test that .claude/settings.json without hooks does not pass."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text('{"permissions": {}}')
+
+        repo = _make_repo(tmp_path)
+        assessor = DeterministicEnforcementAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.status == "fail"
+        assert finding.score == 10.0
+
+    def test_precommit_plus_agent_hooks_scores_100(self, tmp_path):
+        """Test that pre-commit (40) + agent hooks (60) = 100."""
+        (tmp_path / ".pre-commit-config.yaml").write_text("repos: []\n")
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text(
+            '{"hooks": {"PostToolUse": [{"matcher": "Edit", "command": "echo ok"}]}}'
+        )
+
+        repo = _make_repo(tmp_path)
+        assessor = DeterministicEnforcementAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.status == "pass"
+        assert finding.score == 100.0

--- a/tests/unit/test_assessors_testing.py
+++ b/tests/unit/test_assessors_testing.py
@@ -975,22 +975,27 @@ class TestDeterministicEnforcementAssessor:
 
     def test_agent_hooks_score_higher_than_precommit(self, tmp_path):
         """Test that agent hooks (60 pts) score higher than pre-commit (40 pts)."""
-        claude_dir = tmp_path / ".claude"
+        agent_path = tmp_path / "agent"
+        agent_path.mkdir()
+        claude_dir = agent_path / ".claude"
         claude_dir.mkdir()
         (claude_dir / "settings.json").write_text(
             '{"hooks": {"PostToolUse": [{"matcher": "Edit", "command": "echo ok"}]}}'
         )
 
-        repo = _make_repo(tmp_path)
+        repo = _make_repo(agent_path)
         assessor = DeterministicEnforcementAssessor()
         agent_finding = assessor.assess(repo)
 
-        (tmp_path / ".pre-commit-config.yaml").write_text("repos: []\n")
-        precommit_repo = _make_repo(tmp_path)
+        precommit_path = tmp_path / "precommit"
+        precommit_path.mkdir()
+        (precommit_path / ".pre-commit-config.yaml").write_text("repos: []\n")
+        precommit_repo = _make_repo(precommit_path)
         precommit_finding = assessor.assess(precommit_repo)
 
         assert agent_finding.score == 60.0
-        assert precommit_finding.score > 60.0  # 40 + 60 from agent hooks
+        assert precommit_finding.score == 40.0
+        assert agent_finding.score > precommit_finding.score
 
     def test_claude_settings_with_hooks_passes(self, tmp_path):
         """Test that .claude/settings.json with hooks alone passes."""


### PR DESCRIPTION
## Summary

- Reprioritize DeterministicEnforcementAssessor scoring: agent hooks (`.claude/settings.json`) now score 60 pts (up from 30), git hooks (pre-commit/Husky) score 40 pts (down from 60), pass threshold lowered to 40
- Add design doc enforcement detection to DesignIntentAssessor: advisory enforcement in AGENTS.md (+10 pts) or deterministic enforcement via hooks/skills (+15 pts)
- Add two recommended starter hooks to `.claude/settings.json`: auto-format on edit (black + isort) and destructive command blocker
- Update test-assess skill cleanup to use `find -delete` instead of `rm -rf` (which the new hook blocks)

Implements Proposals A.5 and A.8 from the [accepted ADR](docs/adr/2026-05-20-align-with-wg-agentic-sdlc-best-practices.md). Fourth of six implementation PRs.

**Self-score change**: 74.8 -> 75.5 Gold (agent hooks bring deterministic_enforcement from 50 to 100, crossing the Gold threshold).

### A.5: Hook scoring reprioritization

The BP insight: "context file instructions are advisory; hooks are deterministic." Agent hooks always execute during agent workflows and cannot be bypassed, while git hooks can be skipped with `--no-verify`. New scoring:

| Signal | Before | After |
|--------|--------|-------|
| `.claude/settings.json` with hooks | 30 pts | 60 pts |
| `.pre-commit-config.yaml` | 60 pts | 40 pts |
| `.husky` with hook scripts | 60 pts | 40 pts |
| Pass threshold | 60 | 40 |

Repos with only pre-commit still pass (40 >= 40). Repos with only agent hooks now pass (60 >= 40, was 30 < 60).

### A.8: Design intent enforcement detection

The assessor now checks whether design doc updates are enforced, not just whether design docs exist. Two levels:

- **Advisory** (10 pts): AGENTS.md/CLAUDE.md contains rules requiring design doc updates with architectural changes
- **Deterministic** (15 pts): Hooks or skills that enforce design doc updates

The higher of the two is awarded (not additive).

### Starter hooks

Added two hooks from the BP recommended starters to `.claude/settings.json`:

1. **Auto-format on edit**: Runs `black` and `isort` after every Edit/Write
2. **Block destructive operations**: Pattern-matches against `rm -rf`, `DROP TABLE`, `--force`

**Note on the destructive command blocker:** This hook is a lightweight guardrail, not a comprehensive safety solution. An agent can achieve the same destructive effect through alternative commands that don't match the pattern (e.g., `find -delete` instead of `rm -rf`). In practice, many agents won't work around the restriction, so it's a net positive for catching obvious destructive operations, but it should not be relied on as a security boundary.

## Related issues

1. Remove redundant assessors, realign tiers, rebalance weights (#458) - merged in #464
2. Context file assessor improvements (#459) - merged in #477
3. Test assessor enhancements (#460) - merged in #481
4. **This PR** - Enforcement and intent assessor improvements (#461)
5. Code quality assessor enhancements (#462)
6. New assessors for architectural boundaries and threat models (#463)

## Test plan
- [x] `black . && isort . && ruff check .` passes
- [x] `pytest tests/unit/` passes (1122 passed, 17 skipped)
- [x] `agentready assess .` runs successfully (75.5/100 Gold)
- [x] 12 new tests for enforcement scoring and design intent enforcement detection
- [x] All existing tests pass unchanged (except 3 updated for new score values)

Closes #461

Posted by Bill Murdock with assistance from Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic formatting after tool use and a safety check to block destructive shell commands.

* **Documentation**
  * Revised enforcement docs and scoring/threshold guidance for deterministic agent hooks.

* **Bug Fixes**
  * Safer test cleanup to avoid recursive removal of directories.

* **Tests**
  * Expanded coverage for enforcement detection, scoring, and precedence.

* **Chores**
  * Ignore local agent/tooling config files in VCS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->