### PR TITLE
fix: scan AGENTS.md/CLAUDE.md for Go test commands (#470)

### DIFF
--- a/src/agentready/assessors/testing.py
+++ b/src/agentready/assessors/testing.py
@@ -564,12 +564,17 @@ class TestExecutionAssessor(BaseAssessor):
 
         text_sources = self._read_go_build_files(repository)
 
-        has_test_cmd = bool(re.search(r"(?:\bgo|\$\(GO\))\s+test\b", text_sources))
+        has_test_cmd = bool(
+            re.search(
+                r"(?:\bgo|\$\(GO\))\s+test\b|\bmake\s+test\b|\bginkgo\b",
+                text_sources,
+            )
+        )
         if has_test_cmd:
             score += 20.0
             evidence.append("Go test command found in project files")
         else:
-            evidence.append("No 'go test' command found in Makefile/CI/README")
+            evidence.append("No test command found in Makefile/CI/README/AGENTS.md")
 
         has_coverage = bool(
             re.search(r"(?<!\S)-cover(?:\b|profile\b|mode\b)", text_sources)
@@ -634,6 +639,8 @@ class TestExecutionAssessor(BaseAssessor):
             repository.path / "Makefile",
             repository.path / "Taskfile.yml",
             repository.path / "README.md",
+            repository.path / "AGENTS.md",
+            repository.path / "CLAUDE.md",
         ]
 
         # Include module-local build files (Go monorepos)

--- a/tests/unit/test_assessors_go.py
+++ b/tests/unit/test_assessors_go.py
@@ -145,6 +145,29 @@ class TestTestExecutionAssessorGo:
         assert finding.remediation is not None
         assert any("go test" in cmd for cmd in finding.remediation.commands)
 
+    def test_go_test_command_in_agents_md(self, tmp_path):
+        """Go test command documented in AGENTS.md is detected (#470)."""
+        repo = _make_go_repo(tmp_path)
+
+        test_file = tmp_path / "main_test.go"
+        test_file.write_text('package main\nimport "testing"\n')
+        _git_add(tmp_path, test_file)
+
+        agents_md = tmp_path / "AGENTS.md"
+        agents_md.write_text(
+            "## Quick Commands\n\n"
+            "| Action | Command |\n"
+            "|--------|----------|\n"
+            "| Run tests | `make test` (runs fmt and vet first) |\n"
+            "| Lint | `make lint` |\n"
+        )
+
+        assessor = TestExecutionAssessor()
+        finding = assessor.assess(repo)
+
+        assert any("test command found" in e.lower() for e in finding.evidence)
+        assert finding.score >= 60.0
+
 
 # =============================================================================
 # TypeAnnotationsAssessor — Go support


### PR DESCRIPTION
## Summary

Fixes #470.

- **AGENTS.md/CLAUDE.md scanned**: `_read_go_build_files()` now includes these files alongside Makefile, Taskfile.yml, README.md, and CI workflows
- **Broader test command regex**: The main check now matches `make test` and `ginkgo` in addition to `go test` / `$(GO) test`, so repos using build wrappers or the Ginkgo test framework are recognized

The root cause was two-fold: AGENTS.md wasn't in the scan list for the main 20-point "test command found" check, and the regex only matched literal `go test` invocations — missing `make test` wrappers and Ginkgo.

## Test plan

- [x] New test: `make test` in AGENTS.md detected as a GO test command
- [x] All 48 Go assessor tests pass (no regressions)
- [x] Lint clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Go test-command detection to recognize additional patterns including $(GO) go test, make test, and ginkgo
  * Extended project analysis to scan additional documentation files (AGENTS.md, CLAUDE.md) for Go-related configuration and commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->