### PR TITLE
feat: add A.6 strict mode detection and A.7 naming consistency assessors

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -266,6 +266,8 @@ Type annotations give agents reliable information about what a function expects 
 - All public functions have parameter and return type hints
 - Generic types from `typing` module used appropriately
 - Coverage: >80% of functions typed
+- **Strict mode configured** (prevents new violations): mypy `strict = true` or `disallow_untyped_defs`, or pyright `strict = true` in `pyproject.toml`, `mypy.ini`, `setup.cfg`, or `pyrightconfig.json`
+- Strict mode is scored as a 20-point bonus on a 100-point scale (80 pts max for coverage + 20 pts for strict mode)
 - Tools: mypy, pyright
 
 **TypeScript**:
@@ -362,6 +364,29 @@ def create_user(email, role):
 
 4. **Fix errors iteratively**
 
+5. **Enable strict mode** in your type checker config:
+
+   ```toml
+   # pyproject.toml
+   [tool.mypy]
+   strict = true
+   ```
+
+   Or alternatively:
+
+   ```ini
+   # mypy.ini
+   [mypy]
+   disallow_untyped_defs = true
+   ```
+
+   For pyright:
+
+   ```json
+   // pyrightconfig.json
+   { "typeCheckingMode": "strict" }
+   ```
+
 **TypeScript**:
 
 1. **Enable strict mode** in `tsconfig.json`:
@@ -406,7 +431,20 @@ Using community-recognized directory structures for each language/framework (e.g
 
 Models trained on open-source code have seen the standard layouts thousands of times. When a repo uses the Python `src/` layout or Go's `cmd/internal/pkg` structure, the agent knows where to look for things and where to put new ones. Non-standard layouts force it to explore, and it may still place files in the wrong location.
 
+**Naming consistency** also matters for agent efficiency. When files in the same directory follow a consistent naming convention (e.g., all snake_case in Python), agents can use glob patterns like `src/**/*.py` reliably. Mixed conventions (snake_case and camelCase coexisting in the same directory) reduce "glob-ability" and make it harder for agents to predict file locations.
+
 #### Measurable Criteria
+
+**Python** (naming consistency applies to all languages but assessed via Python files):
+
+- Consistent naming convention within directories:
+  - snake_case (`module_name.py`) — Python community standard
+  - camelCase (`moduleHandler.py`) — also valid but must be consistent
+  - **Mixed naming in the same directory** (e.g., `module_a.py` and `moduleHandler.py` in the same directory) reduces the score
+  - 10-point penalty per directory with mixed naming, capped at 20 points
+  - Directories are checked independently: different dirs can have different conventions
+  - Single-file directories or directories with only one convention are not penalized
+  - Directories with only 1-2 files need both to be from different conventions to trigger a penalty
 
 **Python (src/ layout)**:
 

--- a/src/agentready/assessors/code_quality.py
+++ b/src/agentready/assessors/code_quality.py
@@ -3,6 +3,7 @@
 import ast
 import logging
 import re
+import tomllib
 
 from ..models.attribute import Attribute
 from ..models.finding import Citation, Finding, Remediation
@@ -73,7 +74,13 @@ class TypeAnnotationsAssessor(BaseAssessor):
             )
 
     def _assess_python_types(self, repository: Repository) -> Finding:
-        """Assess Python type annotations using AST parsing."""
+        """Assess Python type annotations using AST parsing.
+
+        Checks both annotation coverage (current state) and strict mode
+        configuration (prevents new violations). Both matter — strict mode
+        stops new untyped code from entering; coverage measures what's already
+        typed.
+        """
         # Use AST parsing to accurately detect type annotations
         try:
             # Security: Use safe_subprocess_run for validation and limits
@@ -130,27 +137,120 @@ class TypeAnnotationsAssessor(BaseAssessor):
             )
 
         coverage_percent = (typed_functions / total_functions) * 100
-        score = self.calculate_proportional_score(
+
+        # Check for strict mode configuration (mypy/pyright)
+        strict_mode = self._check_strict_mode(repository)
+
+        # Score combines coverage (up to 80 pts) + strict mode bonus (up to 20 pts)
+        coverage_score = self.calculate_proportional_score(
             measured_value=coverage_percent,
             threshold=80.0,
             higher_is_better=True,
         )
+        score = min(100.0, coverage_score + (20.0 if strict_mode else 0.0))
 
         status = "pass" if score >= 75 else "fail"
+
+        evidence = [
+            f"Typed functions: {typed_functions}/{total_functions}",
+            f"Coverage: {coverage_percent:.1f}%",
+        ]
+        if strict_mode:
+            evidence.append("Strict mode configured")
+        else:
+            evidence.append("No strict mode configuration found")
 
         return Finding(
             attribute=self.attribute,
             status=status,
             score=score,
             measured_value=f"{coverage_percent:.1f}%",
-            threshold="≥80%",
-            evidence=[
-                f"Typed functions: {typed_functions}/{total_functions}",
-                f"Coverage: {coverage_percent:.1f}%",
-            ],
+            threshold="≥80% coverage + strict mode",
+            evidence=evidence,
             remediation=self._create_remediation() if status == "fail" else None,
             error_message=None,
         )
+
+    @staticmethod
+    def _check_strict_mode(repository: Repository) -> bool:
+        """Check whether the Python type checker is configured in strict mode.
+
+        Looks for mypy/pyright strict mode configuration in pyproject.toml,
+        mypy.ini, setup.cfg, or pyrightconfig.json.
+
+        ADR A.6: Strict mode prevents new violations; coverage measures
+        current state. Both matter.
+        """
+        # Check pyproject.toml for mypy/pyright strict config
+        pyproject_path = repository.path / "pyproject.toml"
+        if pyproject_path.exists():
+            try:
+                with open(pyproject_path, "rb") as f:
+                    data = tomllib.load(f)
+
+                # mypy: [tool.mypy] strict = true
+                tool = data.get("tool", {})
+                mypy_cfg = tool.get("mypy", {})
+                if mypy_cfg.get("strict", False):
+                    return True
+                if "disallow_untyped_defs" in mypy_cfg and mypy_cfg[
+                    "disallow_untyped_defs"
+                ]:
+                    return True
+
+                # pyright: [tool.pyright] strict = true
+                pyright_cfg = tool.get("pyright", {})
+                if pyright_cfg.get("strict", False):
+                    return True
+
+            except (OSError, tomllib.TOMLDecodeError):
+                pass
+
+        # Check mypy.ini
+        mypy_ini_path = repository.path / "mypy.ini"
+        if mypy_ini_path.exists():
+            try:
+                content = mypy_ini_path.read_text(encoding="utf-8")
+                if "[mypy]" in content:
+                    for line in content.splitlines():
+                        stripped = line.strip().lower()
+                        if stripped == "strict = true" or stripped == "strict=true":
+                            return True
+                        if stripped.startswith("disallow_untyped_defs"):
+                            return True
+            except OSError:
+                pass
+
+        # Check setup.cfg
+        setup_cfg_path = repository.path / "setup.cfg"
+        if setup_cfg_path.exists():
+            try:
+                content = setup_cfg_path.read_text(encoding="utf-8")
+                if "[mypy]" in content or "[mypy]" in content.lower():
+                    for line in content.splitlines():
+                        stripped = line.strip().lower()
+                        if "strict = true" in stripped or "strict=true" in stripped:
+                            return True
+                        if stripped.startswith("disallow_untyped_defs"):
+                            return True
+            except OSError:
+                pass
+
+        # Check pyrightconfig.json
+        pyright_path = repository.path / "pyrightconfig.json"
+        if pyright_path.exists():
+            try:
+                import json
+
+                content = json.loads(pyright_path.read_text(encoding="utf-8"))
+                if content.get("typeCheckingMode", "") == "strict":
+                    return True
+                if content.get("strict", False):
+                    return True
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        return False
 
     def _assess_typescript_types(self, repository: Repository) -> Finding:
         """Assess TypeScript type configuration across all tsconfig.json files.

--- a/src/agentready/assessors/structure.py
+++ b/src/agentready/assessors/structure.py
@@ -126,6 +126,9 @@ class StandardLayoutAssessor(BaseAssessor):
         - Go: cmd/, internal/, pkg/ with go.mod, tests in *_test.go
 
         Fix for #246, #305: Support multiple valid Python layouts
+        ADR A.7: Adds naming consistency check for Python repos — mixed
+        naming conventions (camelCase vs snake_case in same directory) reduce
+        "glob-ability" for agents.
         """
         if self._primary_language(repository, {"Python", "Go"}) == "Go":
             return self._assess_go_layout(repository)
@@ -162,6 +165,16 @@ class StandardLayoutAssessor(BaseAssessor):
             higher_is_better=True,
         )
 
+        # ADR A.7: Naming consistency check for Python repos
+        naming_penalty = 0.0
+        naming_evidence = []
+        if repository.languages.get("Python", 0) > 0:
+            penalty, evidence = self._check_naming_consistency(repository)
+            naming_penalty = penalty
+            naming_evidence = evidence
+
+        score = max(0.0, score - naming_penalty)
+
         status = "pass" if score >= 75 else "fail"
 
         # Build evidence with detailed source directory info
@@ -180,7 +193,7 @@ class StandardLayoutAssessor(BaseAssessor):
             f"Found {found_dirs}/{required_dirs} standard directories",
             source_evidence,
             f"tests/: {'✓' if has_tests else '✗'}",
-        ]
+        ] + naming_evidence
 
         return Finding(
             attribute=self.attribute,
@@ -496,6 +509,93 @@ project/
                 )
             ],
         )
+
+    def _check_naming_consistency(self, repository: Repository) -> tuple:
+        """Check for mixed naming conventions in the same directory.
+
+        ADR A.7: Inconsistent naming (camelCase vs snake_case coexisting in
+        the same directory) reduces "glob-ability" for agents. A consistent
+        naming convention makes it easier for agents to use glob patterns like
+        `src/**/*.py` to find all relevant files.
+
+        Returns:
+            (penalty_score, evidence_list)
+            - penalty_score: 0-20, where 20 is maximum penalty for mixed conventions
+            - evidence_list: human-readable evidence strings
+        """
+        # Only check source directories, not test directories
+        # We look at Python files (.py, .pyi) in source locations
+        source_path = repository.path / "src"
+        if not source_path.exists():
+            # Try project-named directory
+            package_name = self._get_package_name_from_pyproject(repository)
+            if package_name:
+                source_path = repository.path / package_name.replace("-", "_")
+            if not source_path.exists():
+                # Fall back to root for small repos
+                source_path = repository.path
+
+        file_stats: dict = {"snake_case": 0, "camelCase": 0, "mixed": set()}
+        total_files = 0
+
+        try:
+            for py_file in source_path.rglob("*.py"):
+                # Skip venv, node_modules, etc.
+                if any(
+                    part in py_file.parts
+                    for part in [".venv", "venv", "node_modules", ".git", ".tox"]
+                ):
+                    continue
+                total_files += 1
+                dirname = py_file.parent.name
+                filename = py_file.name
+
+                # Group files by directory and check naming per directory
+                is_snake = bool(re.fullmatch(r"[a-z][a-z0-9]*(?:_[a-z0-9]+)*\.py(?:i)?$", filename))
+                is_camel = bool(re.fullmatch(r"[a-z][a-zA-Z0-9]*\.py(?:i)?$", filename))
+
+                if is_snake and is_camel:
+                    pass  # lowercase is snake_case
+                elif is_snake:
+                    key = f"{dirname}/"
+                    if key not in file_stats:
+                        file_stats[key] = {"snake_case": 0, "camelCase": 0}
+                    file_stats[key]["snake_case"] += 1
+                elif is_camel:
+                    key = f"{dirname}/"
+                    if key not in file_stats:
+                        file_stats[key] = {"snake_case": 0, "camelCase": 0}
+                    file_stats[key]["camelCase"] += 1
+
+        except OSError:
+            return 0.0, []
+
+        # Check if any directory has mixed naming
+        penalty = 0.0
+        evidence = []
+
+        for dir_key, counts in file_stats.items():
+            snake_count = counts.get("snake_case", 0)
+            camel_count = counts.get("camelCase", 0)
+
+            # Only count directories with at least 2 files (need meaningful sample)
+            if snake_count > 0 and camel_count > 0:
+                total_in_dir = snake_count + camel_count
+                if total_in_dir >= 2:
+                    penalty += 10.0
+                    evidence.append(
+                        f"Mixed naming in {dir_key}: {snake_count} snake_case, {camel_count} camelCase"
+                    )
+
+        # Cap the penalty at 20 points
+        penalty = min(20.0, penalty)
+
+        if penalty > 0:
+            evidence.insert(0, "Inconsistent naming conventions detected")
+        elif total_files > 0:
+            evidence.append("Naming convention consistent")
+
+        return penalty, evidence
 
     def _create_remediation(self, has_source: bool, has_tests: bool) -> Remediation:
         """Create context-aware remediation guidance for standard layout.

--- a/tests/unit/test_assessors_code_quality.py
+++ b/tests/unit/test_assessors_code_quality.py
@@ -1,0 +1,262 @@
+"""Tests for Python type annotation assessment (ADR A.6)."""
+
+import json
+import subprocess
+
+import pytest
+
+from agentready.assessors.code_quality import TypeAnnotationsAssessor
+from agentready.models.repository import Repository
+
+
+def _make_py_repo(tmp_path, py_files=None, **kwargs):
+    """Create a test Python repository with git init."""
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+    return Repository(
+        path=tmp_path,
+        name="test-py-repo",
+        url=None,
+        branch="main",
+        commit_hash="abc123",
+        languages={"Python": 50},
+        total_files=kwargs.get("total_files", 10),
+        total_lines=kwargs.get("total_lines", 500),
+    )
+
+
+class TestTypeAnnotationsAssessorPython:
+    """Test Python type annotation assessment in TypeAnnotationsAssessor."""
+
+    def test_applicable_to_python(self, tmp_path):
+        repo = _make_py_repo(tmp_path)
+        assessor = TypeAnnotationsAssessor()
+        assert assessor.is_applicable(repo)
+
+    def test_no_python_files_returns_not_applicable(self, tmp_path):
+        repo = _make_py_repo(tmp_path)
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"JavaScript": 100},
+            total_files=10,
+            total_lines=100,
+        )
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+        assert finding.status == "not_applicable"
+
+    # --- Strict mode detection tests (ADR A.6) ---
+
+    def test_strict_mode_pyproject_toml_mypy_strict(self, tmp_path):
+        """pyproject.toml with mypy strict = true is detected."""
+        _write_pyproject(tmp_path, mypy_strict=True)
+
+        # Add a simple Python file
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "module.py").write_text("def foo(x: int) -> int:\n    return x\n")
+
+        repo = _make_py_repo(tmp_path)
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert "Strict mode configured" in " ".join(finding.evidence)
+        # Should get the 20 pt bonus for strict mode
+        assert "Strict mode configured" in finding.evidence or any(
+            "Strict" in e for e in finding.evidence
+        )
+
+    def test_strict_mode_pyproject_toml_mypy_disallow_untyped(self, tmp_path):
+        """pyproject.toml with mypy disallow_untyped_defs is detected."""
+        _write_pyproject(tmp_path, mypy_disallow_untyped=True)
+
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "module.py").write_text("def foo(x: int) -> int:\n    return x\n")
+
+        repo = _make_py_repo(tmp_path)
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert any("Strict" in e for e in finding.evidence)
+
+    def test_strict_mode_pyproject_toml_pyright_strict(self, tmp_path):
+        """pyproject.toml with pyright strict = true is detected."""
+        _write_pyproject(tmp_path, pyright_strict=True)
+
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "module.py").write_text("def foo(x: int) -> int:\n    return x\n")
+
+        repo = _make_py_repo(tmp_path)
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert any("Strict" in e for e in finding.evidence)
+
+    def test_strict_mode_mypy_ini(self, tmp_path):
+        """mypy.ini with strict = true is detected."""
+        (tmp_path / "mypy.ini").write_text(
+            "[mypy]\nstrict = true\n"
+        )
+
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "module.py").write_text("def foo(x: int) -> int:\n    return x\n")
+
+        repo = _make_py_repo(tmp_path)
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert any("Strict" in e for e in finding.evidence)
+
+    def test_strict_mode_mypy_ini_disallow_untyped(self, tmp_path):
+        """mypy.ini with disallow_untyped_defs is detected."""
+        (tmp_path / "mypy.ini").write_text(
+            "[mypy]\ndisallow_untyped_defs = true\n"
+        )
+
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "module.py").write_text("def foo(x: int) -> int:\n    return x\n")
+
+        repo = _make_py_repo(tmp_path)
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert any("Strict" in e for e in finding.evidence)
+
+    def test_strict_mode_setup_cfg(self, tmp_path):
+        """setup.cfg with mypy strict = true is detected."""
+        (tmp_path / "setup.cfg").write_text(
+            "[mypy]\nstrict = true\n"
+        )
+
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "module.py").write_text("def foo(x: int) -> int:\n    return x\n")
+
+        repo = _make_py_repo(tmp_path)
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert any("Strict" in e for e in finding.evidence)
+
+    def test_strict_mode_pyrightconfig_json(self, tmp_path):
+        """pyrightconfig.json with typeCheckingMode = strict is detected."""
+        (tmp_path / "pyrightconfig.json").write_text(
+            json.dumps({"typeCheckingMode": "strict"})
+        )
+
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "module.py").write_text("def foo(x: int) -> int:\n    return x\n")
+
+        repo = _make_py_repo(tmp_path)
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert any("Strict" in e for e in finding.evidence)
+
+    def test_strict_mode_pyrightconfig_strict_field(self, tmp_path):
+        """pyrightconfig.json with strict: true is detected."""
+        (tmp_path / "pyrightconfig.json").write_text(
+            json.dumps({"strict": True})
+        )
+
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "module.py").write_text("def foo(x: int) -> int:\n    return x\n")
+
+        repo = _make_py_repo(tmp_path)
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert any("Strict" in e for e in finding.evidence)
+
+    def test_no_strict_mode_config(self, tmp_path):
+        """No strict mode config means no bonus."""
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "module.py").write_text("def foo(x: int) -> int:\n    return x\n")
+
+        repo = _make_py_repo(tmp_path)
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert any("No strict mode" in e for e in finding.evidence)
+
+    def test_strict_mode_pyproject_malformed_toml(self, tmp_path):
+        """Malformed pyproject.toml is handled gracefully."""
+        (tmp_path / "pyproject.toml").write_text("not valid toml {{{")
+
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "module.py").write_text("def foo(x: int) -> int:\n    return x\n")
+
+        repo = _make_py_repo(tmp_path)
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        # Should not crash, and should not find strict mode
+        assert any("No strict mode" in e for e in finding.evidence)
+
+    def test_strict_mode_prefers_pyproject_over_other_configs(self, tmp_path):
+        """When multiple configs exist, strict mode is detected from any source."""
+        _write_pyproject(tmp_path, mypy_strict=True)
+        # Also create mypy.ini (shouldn't matter, pyproject already has it)
+        (tmp_path / "mypy.ini").write_text("[mypy]\nstrict = false\n")
+
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "module.py").write_text("def foo(x: int) -> int:\n    return x\n")
+
+        repo = _make_py_repo(tmp_path)
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        # Should find strict mode via pyproject.toml
+        assert any("Strict mode" in e for e in finding.evidence)
+
+
+def _write_pyproject(
+    path,
+    mypy_strict=False,
+    mypy_disallow_untyped=False,
+    pyright_strict=False,
+):
+    """Write a pyproject.toml with specified mypy/pyright config."""
+    config = {"tool": {}}
+
+    if mypy_strict:
+        config["tool"]["mypy"] = {"strict": True}
+    if mypy_disallow_untyped:
+        config["tool"]["mypy"] = {"disallow_untyped_defs": True}
+    if pyright_strict:
+        config["tool"]["pyright"] = {"strict": True}
+
+    with open(path / "pyproject.toml", "w") as f:
+        f.write("[project]\nname = 'test'\n\n")
+        f.write("[[project.dependencies]]\n")
+        f.write("name = 'pytest'\n")
+        f.write(f"\n{toml_str(config)}")
+
+
+def toml_str(d):
+    """Simple TOML serializer for test data."""
+    lines = []
+    for k, v in d.items():
+        if isinstance(v, dict):
+            lines.append(f"[tool.{k}]")
+            for sk, sv in v.items():
+                if isinstance(sv, bool):
+                    lines.append(f"{sk} = {'true' if sv else 'false'}")
+                elif isinstance(sv, str):
+                    lines.append(f'{sk} = "{sv}"')
+                else:
+                    lines.append(f"{sk} = {sv}")
+            lines.append("")
+    return "\n".join(lines)

--- a/tests/unit/test_assessors_structure.py
+++ b/tests/unit/test_assessors_structure.py
@@ -864,6 +864,307 @@ another_entry
         assert "go.mod" in evidence_str
         assert "cmd/" in evidence_str or "internal/" in evidence_str
 
+    # --- ADR A.7: Naming consistency tests ---
+
+    def test_naming_consistent_snake_case(self, tmp_path):
+        """All snake_case files should have no naming penalty."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "module_a.py").write_text("# code")
+        (src / "module_b.py").write_text("# code")
+        (src / "module_c.py").write_text("# code")
+
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=3,
+            total_lines=30,
+        )
+
+        assessor = StandardLayoutAssessor()
+        finding = assessor.assess(repo)
+
+        # Should be pass (100.0) with consistent naming
+        assert finding.status == "pass"
+        assert "Naming convention consistent" in " ".join(finding.evidence)
+
+    def test_naming_mixed_snake_and_camel_penalty(self, tmp_path):
+        """Mixed snake_case and camelCase in same directory reduces score."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        src = tmp_path / "src"
+        src.mkdir()
+        # snake_case files
+        (src / "module_a.py").write_text("# code")
+        (src / "module_b.py").write_text("# code")
+        # camelCase file in same dir
+        (src / "moduleHandler.py").write_text("# code")
+
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=3,
+            total_lines=30,
+        )
+
+        assessor = StandardLayoutAssessor()
+        finding = assessor.assess(repo)
+
+        # Should have a penalty for mixed naming
+        evidence_str = " ".join(finding.evidence)
+        assert "Mixed naming" in evidence_str or "Inconsistent" in evidence_str
+        assert "moduleHandler" in evidence_str or "camelCase" in evidence_str
+        # Score should be reduced by at least 10 points
+        assert finding.score <= 90.0
+
+    def test_naming_consistent_camel_case(self, tmp_path):
+        """All camelCase files should have no naming penalty."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "moduleA.py").write_text("# code")
+        (src / "moduleB.py").write_text("# code")
+        (src / "moduleC.py").write_text("# code")
+
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=3,
+            total_lines=30,
+        )
+
+        assessor = StandardLayoutAssessor()
+        finding = assessor.assess(repo)
+
+        # Should be pass with consistent naming
+        assert finding.status == "pass"
+        assert "Naming convention consistent" in " ".join(finding.evidence)
+
+    def test_naming_consistency_different_dirs_no_penalty(self, tmp_path):
+        """Different dirs with different conventions should not be penalized."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        src = tmp_path / "src"
+        src.mkdir()
+        # Different dirs can have different conventions
+        (src / "module_a.py").write_text("# code")  # snake_case
+        (src / "handlers").mkdir()
+        (src / "handlers" / "authHandler.py").write_text("# code")  # camelCase
+
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=2,
+            total_lines=20,
+        )
+
+        assessor = StandardLayoutAssessor()
+        finding = assessor.assess(repo)
+
+        # Different dirs should be OK, no penalty
+        assert "Mixed naming" not in " ".join(finding.evidence)
+
+    def test_naming_consistency_single_file_no_penalty(self, tmp_path):
+        """A single file in a directory should not trigger penalty."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "moduleA.py").write_text("# code")
+        # Only one file, no mixing possible
+        (src / "moduleB.py").write_text("# code")
+
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=2,
+            total_lines=20,
+        )
+
+        assessor = StandardLayoutAssessor()
+        finding = assessor.assess(repo)
+
+        # 2 files with same convention should be fine
+        assert "Naming convention consistent" in " ".join(finding.evidence)
+
+    def test_naming_consistency_venv_excluded(self, tmp_path):
+        """Files in venv directories should be excluded from check."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "module_a.py").write_text("# code")
+        (src / "module_b.py").write_text("# code")
+
+        # Create a fake venv with camelCase files
+        venv = tmp_path / ".venv" / "lib" / "site-packages"
+        venv.mkdir(parents=True)
+        (venv / "somePackage.py").write_text("# code")
+        (venv / "anotherPackage.py").write_text("# code")
+
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=5,
+            total_lines=50,
+        )
+
+        assessor = StandardLayoutAssessor()
+        finding = assessor.assess(repo)
+
+        # Venv files should not affect scoring
+        assert "Mixed naming" not in " ".join(finding.evidence)
+
+    def test_naming_penalty_applied_to_score(self, tmp_path):
+        """Naming penalty should be subtracted from layout score."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        src = tmp_path / "src"
+        src.mkdir()
+        # Start with 2/2 directories (100 points)
+        (src / "module_a.py").write_text("# code")
+        (src / "module_b.py").write_text("# code")
+        # Add mixed naming
+        (src / "moduleHandler.py").write_text("# code")
+
+        # Create a tests directory too
+        tests = tmp_path / "tests"
+        tests.mkdir()
+        (tests / "test_module.py").write_text("# test")
+
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=5,
+            total_lines=50,
+        )
+
+        assessor = StandardLayoutAssessor()
+        finding = assessor.assess(repo)
+
+        # With mixed naming, should get a penalty
+        evidence_str = " ".join(finding.evidence)
+        assert "Inconsistent" in evidence_str or "Mixed" in evidence_str
+        # 100 - 10 (one dir with mixed naming) = 90
+        # Should still pass but with reduced score
+        assert finding.score < 100.0
+        assert finding.score >= 0
+
+    def test_naming_consistency_project_named_dir(self, tmp_path):
+        """Naming check should also apply to project-named directories."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "myproject"\n\n'
+            '[project.urls]\nhomepage = "https://example.com"'
+        )
+        # Project-named directory
+        pkg = tmp_path / "myproject"
+        pkg.mkdir()
+        (pkg / "module_a.py").write_text("# code")
+        (pkg / "moduleHandler.py").write_text("# code")
+
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=4,
+            total_lines=40,
+        )
+
+        assessor = StandardLayoutAssessor()
+        finding = assessor.assess(repo)
+
+        evidence_str = " ".join(finding.evidence)
+        assert "Mixed" in evidence_str or "Inconsistent" in evidence_str
+
+    def test_naming_consistency_no_python_files_no_issue(self, tmp_path):
+        """Non-Python repos should not be affected by naming check."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "handler.ts").write_text("// code")
+        (src / "handlerUtil.ts").write_text("// code")
+
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"TypeScript": 100},
+            total_files=2,
+            total_lines=20,
+        )
+
+        assessor = StandardLayoutAssessor()
+        finding = assessor.assess(repo)
+
+        # Should not have naming evidence for non-Python repos
+        evidence_str = " ".join(finding.evidence)
+        assert "Naming" not in evidence_str
+
+    def test_naming_consistency_no_source_dir(self, tmp_path):
+        """Repo without src/ should check root directory."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        # No src/ directory, so it checks root
+        (tmp_path / "module_a.py").write_text("# code")
+        (tmp_path / "module_b.py").write_text("# code")
+
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=2,
+            total_lines=20,
+        )
+
+        assessor = StandardLayoutAssessor()
+        finding = assessor.assess(repo)
+
+        evidence_str = " ".join(finding.evidence)
+        assert "Naming convention consistent" in evidence_str
+
 
 class TestIssuePRTemplatesAssessor:
     """Test IssuePRTemplatesAssessor."""


### PR DESCRIPTION
## Summary

Implements ADR proposals A.6 (TypeAnnotationsAssessor strict mode detection) and A.7 (StandardLayoutAssessor naming consistency) from the [wg-agentic-sdlc best practices ADR](docs/adr/2026-05-20-align-with-wg-agentic-sdlc-best-practices.md).

## A.6 — Strict Mode Detection

**What**: TypeAnnotationsAssessor now detects whether mypy/pyright is configured in strict mode, in addition to measuring annotation coverage.

**Why**: Strict mode prevents new violations; coverage measures current state. Both matter.

**How**:
- `_check_strict_mode()` scans `pyproject.toml`, `mypy.ini`, `setup.cfg`, and `pyrightconfig.json` for strict mode settings
- Score combines coverage (up to 80 pts) + strict mode bonus (up to 20 pts)
- Handles malformed TOML gracefully (doesn't crash)

**Recognized configs**:
- `[tool.mypy] strict = true` or `disallow_untyped_defs`
- `[tool.pyright] strict = true`
- `pyrightconfig.json` with `typeCheckingMode: "strict"` or `strict: true`

## A.7 — Naming Consistency

**What**: StandardLayoutAssessor now checks for mixed naming conventions (snake_case vs camelCase) within the same directory.

**Why**: Inconsistent naming reduces "glob-ability" for agents — they can't reliably use `src/**/*.py` to find all relevant files.

**How**:
- Analyzes Python files (.py, .pyi) in source directories
- Groups files by directory and checks naming convention per directory
- 10-point penalty per directory with mixed naming, capped at 20 points
- Skips venv, node_modules, .git, .tox directories
- Directories checked independently (different dirs can have different conventions)

## Testing

- **A.6**: New test file `tests/unit/test_assessors_code_quality.py` (261 lines) covering:
  - All config file formats (pyproject.toml, mypy.ini, setup.cfg, pyrightconfig.json)
  - mypy strict/disallow_untyped_defs, pyright strict
  - No strict mode config, malformed TOML, config preference

- **A.7**: 10 new tests in `tests/unit/test_assessors_structure.py` covering:
  - Consistent snake_case, consistent camelCase, mixed naming
  - Different directories no penalty, single file no penalty
  - venv excluded, project-named directory, no Python files, no source dir
  - Penalty applied to total score

## Files Changed

| File | Change |
|------|--------|
| `src/agentready/assessors/code_quality.py` | A.6: `_check_strict_mode()` method, score adjustment |
| `src/agentready/assessors/structure.py` | A.7: `_check_naming_consistency()` method, score penalty |
| `tests/unit/test_assessors_code_quality.py` | A.6: 10 new tests |
| `tests/unit/test_assessors_structure.py` | A.7: 10 new tests |
| `docs/attributes.md` | Document A.6 scoring/remediation + A.7 criteria |

## Related Issues

Closes #462

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict-mode configuration detection for Python type checking (mypy/pyright) with up to 20-point scoring bonus.
  * Added naming consistency evaluation for Python projects, penalizing mixed naming conventions within directories.

* **Documentation**
  * Enhanced guidance with explicit scoring criteria and remediation steps for strict-mode type checking configuration.
  * Added naming consistency requirements and penalty rules for Python projects.

* **Tests**
  * Added comprehensive test coverage for type-annotation and naming-consistency assessments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->