### PR TITLE
feat: code quality assessor enhancements (ADR A.6, A.7)

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -266,6 +266,7 @@ Type annotations give agents reliable information about what a function expects 
 - All public functions have parameter and return type hints
 - Generic types from `typing` module used appropriately
 - Coverage: >80% of functions typed
+- **Strict mode bonus** (+15 pts): type checker configured in strict mode. Checked configs: `mypy.ini`/`.mypy.ini` (`strict = true` or `disallow_untyped_defs = true`), `setup.cfg` `[mypy]`, `pyproject.toml` `[tool.mypy]`, `pyrightconfig.json` (`typeCheckingMode: "strict"`), `pyproject.toml` `[tool.pyright]`
 - Tools: mypy, pyright
 
 **TypeScript**:
@@ -458,6 +459,8 @@ project/
 ├── pom.xml
 └── target/
 ```
+
+**Naming consistency** (evidence only, no score impact): The assessor checks for mixed file naming conventions (snake_case vs camelCase vs PascalCase vs kebab-case) within the same directory. Inconsistent naming reduces "glob-ability" for agents trying to predict file names. Directories with fewer than 3 classifiable files are skipped.
 
 #### Remediation
 

--- a/src/agentready/assessors/code_quality.py
+++ b/src/agentready/assessors/code_quality.py
@@ -1,8 +1,10 @@
 """Code quality assessors for complexity, file length, type annotations, and code smells."""
 
 import ast
+import configparser
 import logging
 import re
+import tomllib
 
 from ..models.attribute import Attribute
 from ..models.finding import Citation, Finding, Remediation
@@ -136,6 +138,16 @@ class TypeAnnotationsAssessor(BaseAssessor):
             higher_is_better=True,
         )
 
+        evidence = [
+            f"Typed functions: {typed_functions}/{total_functions}",
+            f"Coverage: {coverage_percent:.1f}%",
+        ]
+
+        strict_pts, strict_evidence = self._check_python_strict_mode(repository)
+        if strict_pts > 0:
+            score = min(score + strict_pts, 100.0)
+            evidence.extend(strict_evidence)
+
         status = "pass" if score >= 75 else "fail"
 
         return Finding(
@@ -144,13 +156,85 @@ class TypeAnnotationsAssessor(BaseAssessor):
             score=score,
             measured_value=f"{coverage_percent:.1f}%",
             threshold="≥80%",
-            evidence=[
-                f"Typed functions: {typed_functions}/{total_functions}",
-                f"Coverage: {coverage_percent:.1f}%",
-            ],
+            evidence=evidence,
             remediation=self._create_remediation() if status == "fail" else None,
             error_message=None,
         )
+
+    def _check_python_strict_mode(
+        self, repository: Repository
+    ) -> tuple[float, list[str]]:
+        """Check whether a Python type checker is configured in strict mode.
+
+        Awards 15 bonus points if strict mode is detected in any of:
+        mypy.ini, .mypy.ini, setup.cfg [mypy], pyproject.toml [tool.mypy],
+        pyrightconfig.json, or pyproject.toml [tool.pyright].
+        """
+        import json
+
+        # Check INI-style mypy configs
+        for ini_name in ("mypy.ini", ".mypy.ini", "setup.cfg"):
+            ini_path = repository.path / ini_name
+            if not ini_path.exists():
+                continue
+            try:
+                parser = configparser.ConfigParser()
+                parser.read(str(ini_path), encoding="utf-8")
+                if parser.has_section("mypy"):
+                    strict = parser.get("mypy", "strict", fallback="").lower()
+                    disallow = parser.get(
+                        "mypy", "disallow_untyped_defs", fallback=""
+                    ).lower()
+                    if strict == "true" or disallow == "true":
+                        return 15.0, [
+                            f"mypy strict mode configured in {ini_name} "
+                            "(prevents new type violations)"
+                        ]
+            except (OSError, configparser.Error):
+                continue
+
+        # Check pyproject.toml for [tool.mypy] and [tool.pyright]
+        pyproject_path = repository.path / "pyproject.toml"
+        if pyproject_path.exists():
+            try:
+                with open(pyproject_path, "rb") as f:
+                    data = tomllib.load(f)
+
+                mypy_cfg = data.get("tool", {}).get("mypy", {})
+                if (
+                    mypy_cfg.get("strict") is True
+                    or mypy_cfg.get("disallow_untyped_defs") is True
+                ):
+                    return 15.0, [
+                        "mypy strict mode configured in pyproject.toml "
+                        "(prevents new type violations)"
+                    ]
+
+                pyright_cfg = data.get("tool", {}).get("pyright", {})
+                if pyright_cfg.get("typeCheckingMode") == "strict":
+                    return 15.0, [
+                        "pyright strict mode configured in pyproject.toml "
+                        "(prevents new type violations)"
+                    ]
+            except (OSError, tomllib.TOMLDecodeError):
+                pass
+
+        # Check pyrightconfig.json (supports JSONC comments)
+        pyright_path = repository.path / "pyrightconfig.json"
+        if pyright_path.exists():
+            try:
+                raw = pyright_path.read_text(encoding="utf-8")
+                cleaned = self._strip_json_comments(raw)
+                config = json.loads(cleaned)
+                if config.get("typeCheckingMode") == "strict":
+                    return 15.0, [
+                        "pyright strict mode configured in pyrightconfig.json "
+                        "(prevents new type violations)"
+                    ]
+            except (OSError, json.JSONDecodeError):
+                pass
+
+        return 0.0, []
 
     def _assess_typescript_types(self, repository: Repository) -> Finding:
         """Assess TypeScript type configuration across all tsconfig.json files.

--- a/src/agentready/assessors/structure.py
+++ b/src/agentready/assessors/structure.py
@@ -443,6 +443,8 @@ class StandardLayoutAssessor(BaseAssessor):
 
         Returns None for single-word lowercase names (neutral, e.g. "main").
         """
+        if not name:
+            return None
         if "_" in name and name == name.lower():
             return "snake_case"
         if "-" in name and name == name.lower():

--- a/src/agentready/assessors/structure.py
+++ b/src/agentready/assessors/structure.py
@@ -182,6 +182,9 @@ class StandardLayoutAssessor(BaseAssessor):
             f"tests/: {'✓' if has_tests else '✗'}",
         ]
 
+        naming_evidence = self._check_naming_consistency(repository)
+        evidence.extend(naming_evidence)
+
         return Finding(
             attribute=self.attribute,
             status=status,
@@ -411,6 +414,9 @@ class StandardLayoutAssessor(BaseAssessor):
         else:
             evidence.append("*_test.go files: ✗ (no test files found)")
 
+        naming_evidence = self._check_naming_consistency(repository)
+        evidence.extend(naming_evidence)
+
         score = min(score, 100.0)
         status = "pass" if score >= 75 else "fail"
 
@@ -430,6 +436,91 @@ class StandardLayoutAssessor(BaseAssessor):
             ),
             error_message=None,
         )
+
+    @staticmethod
+    def _classify_naming_convention(name: str) -> str | None:
+        """Classify a filename (without extension) into a naming convention.
+
+        Returns None for single-word lowercase names (neutral, e.g. "main").
+        """
+        if "_" in name and name == name.lower():
+            return "snake_case"
+        if "-" in name and name == name.lower():
+            return "kebab-case"
+        if name[0].isupper() and any(c.islower() for c in name):
+            return "PascalCase"
+        if name[0].islower() and any(c.isupper() for c in name) and "_" not in name:
+            return "camelCase"
+        return None
+
+    def _check_naming_consistency(self, repository: Repository) -> list[str]:
+        """Check for mixed file naming conventions within directories.
+
+        Reports as evidence only (no score impact). Mixed conventions
+        reduce "glob-ability" for agents trying to predict file names.
+        """
+        from collections import defaultdict
+
+        from ..utils.subprocess_utils import safe_subprocess_run
+
+        try:
+            result = safe_subprocess_run(
+                ["git", "ls-files"],
+                cwd=repository.path,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode != 0:
+                return []
+            files = [f for f in result.stdout.strip().split("\n") if f]
+        except Exception:
+            return []
+
+        skip_names = {"__init__", "__main__", "conftest", "setup"}
+        dir_conventions: dict[str, dict[str, int]] = defaultdict(
+            lambda: defaultdict(int)
+        )
+
+        for filepath in files:
+            p = Path(filepath)
+            parts = p.parts
+            if any(
+                part.startswith(".") or part in ("node_modules", "__pycache__")
+                for part in parts
+            ):
+                continue
+
+            stem = p.stem
+            if stem.startswith("_") or stem in skip_names:
+                continue
+
+            convention = self._classify_naming_convention(stem)
+            if convention is None:
+                continue
+
+            parent = str(p.parent) if p.parent != Path(".") else "."
+            dir_conventions[parent][convention] += 1
+
+        mixed_dirs = []
+        for dirname, conventions in sorted(dir_conventions.items()):
+            if sum(conventions.values()) < 3:
+                continue
+            if len(conventions) >= 2:
+                mixed_dirs.append(dirname)
+
+        if mixed_dirs:
+            dirs_display = ", ".join(mixed_dirs[:3])
+            suffix = f" (+{len(mixed_dirs) - 3} more)" if len(mixed_dirs) > 3 else ""
+            return [
+                f"Naming consistency: mixed conventions in {dirs_display}{suffix} "
+                "(reduces glob-ability for agents)"
+            ]
+
+        if dir_conventions:
+            return ["Naming consistency: ✓ (consistent conventions)"]
+
+        return []
 
     def _create_go_remediation(
         self,

--- a/tests/unit/test_assessors_code_quality.py
+++ b/tests/unit/test_assessors_code_quality.py
@@ -1,0 +1,245 @@
+"""Tests for Python type annotation strict mode detection (ADR A.6)."""
+
+import json
+import subprocess
+
+from agentready.assessors.code_quality import TypeAnnotationsAssessor
+from agentready.models.repository import Repository
+
+
+def _make_python_repo(tmp_path, **kwargs):
+    """Create a test Python repository with git init and typed functions."""
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+
+    # Create a Python file with typed functions for a passing coverage score
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "__init__.py").touch()
+    (src_dir / "main.py").write_text(
+        "def greet(name: str) -> str:\n"
+        "    return f'Hello {name}'\n\n"
+        "def add(a: int, b: int) -> int:\n"
+        "    return a + b\n\n"
+        "def multiply(x: float, y: float) -> float:\n"
+        "    return x * y\n"
+    )
+
+    subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True, check=True)
+
+    return Repository(
+        path=tmp_path,
+        name="test-python-repo",
+        url=None,
+        branch="main",
+        commit_hash="abc123",
+        languages=kwargs.get("languages", {"Python": 100}),
+        total_files=kwargs.get("total_files", 10),
+        total_lines=kwargs.get("total_lines", 1000),
+    )
+
+
+def _make_python_repo_low_coverage(tmp_path, **kwargs):
+    """Create a test Python repository with low type annotation coverage."""
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "__init__.py").touch()
+    (src_dir / "main.py").write_text(
+        "def greet(name):\n"
+        "    return f'Hello {name}'\n\n"
+        "def add(a, b):\n"
+        "    return a + b\n\n"
+        "def multiply(x, y):\n"
+        "    return x * y\n\n"
+        "def typed_func(x: int) -> int:\n"
+        "    return x\n"
+    )
+
+    subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True, check=True)
+
+    return Repository(
+        path=tmp_path,
+        name="test-python-repo",
+        url=None,
+        branch="main",
+        commit_hash="abc123",
+        languages=kwargs.get("languages", {"Python": 100}),
+        total_files=kwargs.get("total_files", 10),
+        total_lines=kwargs.get("total_lines", 1000),
+    )
+
+
+class TestPythonStrictModeDetection:
+    """Test Python type checker strict mode detection (ADR A.6)."""
+
+    def test_mypy_ini_strict_bonus(self, tmp_path):
+        """mypy.ini with strict = true adds 15 bonus points."""
+        repo = _make_python_repo(tmp_path)
+        (tmp_path / "mypy.ini").write_text("[mypy]\nstrict = true\n")
+
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert any("mypy strict mode" in e for e in finding.evidence)
+        assert any("mypy.ini" in e for e in finding.evidence)
+
+    def test_dot_mypy_ini_strict_bonus(self, tmp_path):
+        """`.mypy.ini` with strict = true adds bonus."""
+        repo = _make_python_repo(tmp_path)
+        (tmp_path / ".mypy.ini").write_text("[mypy]\nstrict = true\n")
+
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert any("mypy strict mode" in e for e in finding.evidence)
+        assert any(".mypy.ini" in e for e in finding.evidence)
+
+    def test_setup_cfg_mypy_strict_bonus(self, tmp_path):
+        """setup.cfg [mypy] with strict = true adds bonus."""
+        repo = _make_python_repo(tmp_path)
+        (tmp_path / "setup.cfg").write_text("[mypy]\nstrict = true\n")
+
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert any("mypy strict mode" in e for e in finding.evidence)
+        assert any("setup.cfg" in e for e in finding.evidence)
+
+    def test_mypy_disallow_untyped_defs_bonus(self, tmp_path):
+        """mypy.ini with disallow_untyped_defs = true triggers bonus."""
+        repo = _make_python_repo(tmp_path)
+        (tmp_path / "mypy.ini").write_text("[mypy]\ndisallow_untyped_defs = true\n")
+
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert any("mypy strict mode" in e for e in finding.evidence)
+
+    def test_pyproject_mypy_strict_bonus(self, tmp_path):
+        """pyproject.toml [tool.mypy] strict = true adds bonus."""
+        repo = _make_python_repo(tmp_path)
+        (tmp_path / "pyproject.toml").write_text("[tool.mypy]\nstrict = true\n")
+
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert any("mypy strict mode" in e for e in finding.evidence)
+        assert any("pyproject.toml" in e for e in finding.evidence)
+
+    def test_pyproject_pyright_strict_bonus(self, tmp_path):
+        """pyproject.toml [tool.pyright] typeCheckingMode = 'strict' adds bonus."""
+        repo = _make_python_repo(tmp_path)
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.pyright]\ntypeCheckingMode = "strict"\n'
+        )
+
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert any("pyright strict mode" in e for e in finding.evidence)
+        assert any("pyproject.toml" in e for e in finding.evidence)
+
+    def test_pyrightconfig_json_strict_bonus(self, tmp_path):
+        """pyrightconfig.json with typeCheckingMode: strict adds bonus."""
+        repo = _make_python_repo(tmp_path)
+        (tmp_path / "pyrightconfig.json").write_text(
+            json.dumps({"typeCheckingMode": "strict"})
+        )
+
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert any("pyright strict mode" in e for e in finding.evidence)
+        assert any("pyrightconfig.json" in e for e in finding.evidence)
+
+    def test_pyrightconfig_json_with_comments(self, tmp_path):
+        """pyrightconfig.json with JSONC comments is parsed correctly."""
+        repo = _make_python_repo(tmp_path)
+        (tmp_path / "pyrightconfig.json").write_text(
+            '{\n  // strict type checking\n  "typeCheckingMode": "strict"\n}\n'
+        )
+
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert any("pyright strict mode" in e for e in finding.evidence)
+
+    def test_no_strict_config_no_bonus(self, tmp_path):
+        """No type checker config means no strict mode bonus."""
+        repo = _make_python_repo(tmp_path)
+
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert not any("strict mode" in e for e in finding.evidence)
+
+    def test_mypy_ini_without_strict_no_bonus(self, tmp_path):
+        """mypy.ini without strict settings gives no bonus."""
+        repo = _make_python_repo(tmp_path)
+        (tmp_path / "mypy.ini").write_text("[mypy]\nwarn_return_any = true\n")
+
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert not any("strict mode" in e for e in finding.evidence)
+
+    def test_strict_mode_capped_at_100(self, tmp_path):
+        """High coverage + strict mode doesn't exceed 100."""
+        repo = _make_python_repo(tmp_path)
+        (tmp_path / "mypy.ini").write_text("[mypy]\nstrict = true\n")
+
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.score <= 100.0
+
+    def test_strict_mode_improves_low_coverage_score(self, tmp_path):
+        """Strict mode adds 15 pts to a low-coverage repo's score."""
+        no_strict_dir = tmp_path / "no_strict"
+        no_strict_dir.mkdir()
+        repo_no_strict = _make_python_repo_low_coverage(no_strict_dir)
+        assessor = TypeAnnotationsAssessor()
+        baseline = assessor.assess(repo_no_strict)
+
+        with_strict_dir = tmp_path / "with_strict"
+        with_strict_dir.mkdir()
+        repo_with_strict = _make_python_repo_low_coverage(with_strict_dir)
+        (with_strict_dir / "mypy.ini").write_text("[mypy]\nstrict = true\n")
+        with_strict = assessor.assess(repo_with_strict)
+
+        assert with_strict.score == baseline.score + 15.0
+
+    def test_pyproject_mypy_disallow_untyped_defs_bonus(self, tmp_path):
+        """pyproject.toml [tool.mypy] disallow_untyped_defs = true triggers bonus."""
+        repo = _make_python_repo(tmp_path)
+        (tmp_path / "pyproject.toml").write_text(
+            "[tool.mypy]\ndisallow_untyped_defs = true\n"
+        )
+
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert any("mypy strict mode" in e for e in finding.evidence)
+
+    def test_malformed_pyproject_no_crash(self, tmp_path):
+        """Malformed pyproject.toml doesn't crash the strict mode check."""
+        repo = _make_python_repo(tmp_path)
+        (tmp_path / "pyproject.toml").write_text("not valid toml {{{")
+
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.status in ("pass", "fail")
+        assert not any("strict mode" in e for e in finding.evidence)
+
+    def test_malformed_pyrightconfig_no_crash(self, tmp_path):
+        """Malformed pyrightconfig.json doesn't crash the strict mode check."""
+        repo = _make_python_repo(tmp_path)
+        (tmp_path / "pyrightconfig.json").write_text("not valid json !!!")
+
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.status in ("pass", "fail")
+        assert not any("strict mode" in e for e in finding.evidence)

--- a/tests/unit/test_assessors_structure.py
+++ b/tests/unit/test_assessors_structure.py
@@ -1085,6 +1085,9 @@ class TestNamingConventionClassifier:
     def test_all_caps_neutral(self):
         assert StandardLayoutAssessor._classify_naming_convention("CHANGELOG") is None
 
+    def test_empty_string_neutral(self):
+        assert StandardLayoutAssessor._classify_naming_convention("") is None
+
 
 class TestIssuePRTemplatesAssessor:
     """Test IssuePRTemplatesAssessor."""

--- a/tests/unit/test_assessors_structure.py
+++ b/tests/unit/test_assessors_structure.py
@@ -864,6 +864,227 @@ another_entry
         assert "go.mod" in evidence_str
         assert "cmd/" in evidence_str or "internal/" in evidence_str
 
+    # === Tests for ADR A.7: Naming consistency ===
+
+    def test_naming_consistency_all_snake_case(self, tmp_path):
+        """Consistent snake_case naming shows checkmark in evidence."""
+        import subprocess
+
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+
+        (tmp_path / "src").mkdir()
+        (tmp_path / "tests").mkdir()
+        src_dir = tmp_path / "src" / "mypackage"
+        src_dir.mkdir()
+        for name in [
+            "user_service.py",
+            "auth_handler.py",
+            "data_loader.py",
+            "config_parser.py",
+        ]:
+            (src_dir / name).touch()
+        subprocess.run(
+            ["git", "add", "."], cwd=tmp_path, capture_output=True, check=True
+        )
+
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=10,
+            total_lines=100,
+        )
+
+        assessor = StandardLayoutAssessor()
+        finding = assessor.assess(repo)
+
+        evidence_str = " ".join(finding.evidence)
+        assert "Naming consistency: ✓" in evidence_str
+
+    def test_naming_consistency_mixed_conventions(self, tmp_path):
+        """Mixed naming conventions flagged in evidence."""
+        import subprocess
+
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+
+        (tmp_path / "src").mkdir()
+        (tmp_path / "tests").mkdir()
+        src_dir = tmp_path / "src" / "mypackage"
+        src_dir.mkdir()
+        for name in [
+            "user_service.py",
+            "authHandler.py",
+            "DataLoader.py",
+            "config_parser.py",
+        ]:
+            (src_dir / name).touch()
+        subprocess.run(
+            ["git", "add", "."], cwd=tmp_path, capture_output=True, check=True
+        )
+
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=10,
+            total_lines=100,
+        )
+
+        assessor = StandardLayoutAssessor()
+        finding = assessor.assess(repo)
+
+        evidence_str = " ".join(finding.evidence)
+        assert "mixed conventions" in evidence_str
+        assert "glob-ability" in evidence_str
+
+    def test_naming_consistency_single_word_files_neutral(self, tmp_path):
+        """Single-word files like main.py, app.py don't trigger mixed warning."""
+        import subprocess
+
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+
+        (tmp_path / "src").mkdir()
+        (tmp_path / "tests").mkdir()
+        src_dir = tmp_path / "src" / "mypackage"
+        src_dir.mkdir()
+        for name in ["main.py", "app.py", "config.py", "utils.py"]:
+            (src_dir / name).touch()
+        subprocess.run(
+            ["git", "add", "."], cwd=tmp_path, capture_output=True, check=True
+        )
+
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=10,
+            total_lines=100,
+        )
+
+        assessor = StandardLayoutAssessor()
+        finding = assessor.assess(repo)
+
+        evidence_str = " ".join(finding.evidence)
+        assert "mixed conventions" not in evidence_str
+
+    def test_naming_consistency_too_few_files_skipped(self, tmp_path):
+        """Directories with fewer than 3 classifiable files are not checked."""
+        import subprocess
+
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+
+        (tmp_path / "src").mkdir()
+        (tmp_path / "tests").mkdir()
+        src_dir = tmp_path / "src" / "mypackage"
+        src_dir.mkdir()
+        (src_dir / "user_service.py").touch()
+        (src_dir / "authHandler.py").touch()
+        subprocess.run(
+            ["git", "add", "."], cwd=tmp_path, capture_output=True, check=True
+        )
+
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=10,
+            total_lines=100,
+        )
+
+        assessor = StandardLayoutAssessor()
+        finding = assessor.assess(repo)
+
+        evidence_str = " ".join(finding.evidence)
+        assert "mixed conventions" not in evidence_str
+
+    def test_naming_consistency_does_not_affect_score(self, tmp_path):
+        """Naming consistency check doesn't change the score (evidence only)."""
+        import subprocess
+
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+
+        (tmp_path / "src").mkdir()
+        (tmp_path / "tests").mkdir()
+        src_dir = tmp_path / "src" / "mypackage"
+        src_dir.mkdir()
+        for name in [
+            "user_service.py",
+            "authHandler.py",
+            "DataLoader.py",
+            "config_parser.py",
+        ]:
+            (src_dir / name).touch()
+        subprocess.run(
+            ["git", "add", "."], cwd=tmp_path, capture_output=True, check=True
+        )
+
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=10,
+            total_lines=100,
+        )
+
+        assessor = StandardLayoutAssessor()
+        finding = assessor.assess(repo)
+
+        # Score should be 100 (src + tests present) regardless of naming
+        assert finding.score == 100.0
+        assert finding.status == "pass"
+
+
+class TestNamingConventionClassifier:
+    """Test the static _classify_naming_convention method."""
+
+    def test_snake_case(self):
+        assert (
+            StandardLayoutAssessor._classify_naming_convention("user_service")
+            == "snake_case"
+        )
+
+    def test_camel_case(self):
+        assert (
+            StandardLayoutAssessor._classify_naming_convention("userService")
+            == "camelCase"
+        )
+
+    def test_pascal_case(self):
+        assert (
+            StandardLayoutAssessor._classify_naming_convention("UserService")
+            == "PascalCase"
+        )
+
+    def test_kebab_case(self):
+        assert (
+            StandardLayoutAssessor._classify_naming_convention("user-service")
+            == "kebab-case"
+        )
+
+    def test_single_word_lowercase_neutral(self):
+        assert StandardLayoutAssessor._classify_naming_convention("main") is None
+
+    def test_single_word_uppercase_neutral(self):
+        assert StandardLayoutAssessor._classify_naming_convention("README") is None
+
+    def test_all_caps_neutral(self):
+        assert StandardLayoutAssessor._classify_naming_convention("CHANGELOG") is None
+
 
 class TestIssuePRTemplatesAssessor:
     """Test IssuePRTemplatesAssessor."""


### PR DESCRIPTION
## Summary

- Add Python type checker strict mode detection to TypeAnnotationsAssessor: checks mypy.ini, .mypy.ini, setup.cfg, pyproject.toml [tool.mypy], pyrightconfig.json, and pyproject.toml [tool.pyright] for strict mode config, awarding +15 bonus points (capped at 100)
- Add naming consistency check to StandardLayoutAssessor: scans directories for mixed file naming conventions (snake_case vs camelCase vs PascalCase vs kebab-case) and reports as evidence without affecting score
- Update docs/attributes.md with strict mode bonus and naming consistency documentation

Implements Proposals A.6 and A.7 from the [accepted ADR](docs/adr/2026-05-20-align-with-wg-agentic-sdlc-best-practices.md). Fifth of six implementation PRs.

**Self-score change**: 75.1 Gold (unchanged, since agentready does not have strict mode configured and naming consistency is evidence-only).

### A.6: Python strict mode detection

The ADR insight: "Strict mode prevents new violations; coverage measures current state. Both matter." The existing Python assessment scores on annotation coverage (proportional to 80% threshold). This adds a +15 bonus when strict mode is configured, matching the enforcement bonus pattern from PR #484.

| Config file | Strict indicator |
|-------------|-----------------|
| `mypy.ini` / `.mypy.ini` | `strict = true` or `disallow_untyped_defs = true` |
| `setup.cfg` `[mypy]` | Same as above |
| `pyproject.toml` `[tool.mypy]` | `strict = true` or `disallow_untyped_defs = true` |
| `pyrightconfig.json` | `typeCheckingMode: "strict"` (supports JSONC) |
| `pyproject.toml` `[tool.pyright]` | `typeCheckingMode = "strict"` |

### A.7: Naming consistency

The etirelli/ai-scaffolding skill check 2.5 looks for mixed naming conventions in the same directory. This adds a similar check as evidence (no score impact). Directories with fewer than 3 classifiable files are skipped to avoid false positives.

## Related issues

1. Remove redundant assessors, realign tiers, rebalance weights (#458) - merged in #464
2. Context file assessor improvements (#459) - merged in #477
3. Test assessor enhancements (#460) - merged in #481
4. Enforcement and intent assessor improvements (#461) - merged in #484
5. **This PR** - Code quality assessor enhancements (#462)
6. New assessors for architectural boundaries and threat models (#463)

## Test plan
- [x] `black . && isort . && ruff check .` passes
- [x] `pytest tests/unit/` passes (1173 passed, 17 skipped)
- [x] `agentready assess .` runs successfully (75.1/100 Gold, unchanged)
- [x] 16 new tests for Python strict mode detection
- [x] 12 new tests for naming consistency (5 integration + 7 classifier unit tests)
- [x] All existing tests pass unchanged

Closes #462

Posted by Bill Murdock with assistance from Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Type-annotation assessment gains a Strict-mode bonus (+15 pts) when strict type-checking is detected.
  * Layout assessment adds naming-consistency evidence (reports mixed vs. consistent conventions); evidence-only—no score impact; directories with fewer than 3 classifiable files are skipped.

* **Documentation**
  * Updated scoring docs for Type Annotations and Standard Project Layout.

* **Tests**
  * Added tests covering strict-mode detection, robustness to malformed configs, and naming-consistency behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->