### PR TITLE
fix: skip test files and test functions in Python type annotations check

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -267,6 +267,7 @@ Type annotations give agents reliable information about what a function expects 
 - Generic types from `typing` module used appropriately
 - Coverage: >80% of functions typed
 - **Strict mode bonus** (+15 pts): type checker configured in strict mode. Checked configs: `mypy.ini`/`.mypy.ini` (`strict = true` or `disallow_untyped_defs = true`), `setup.cfg` `[mypy]`, `pyproject.toml` `[tool.mypy]`, `pyrightconfig.json` (`typeCheckingMode: "strict"`), `pyproject.toml` `[tool.pyright]`
+- Test files and test functions (`test_*`) are excluded from scoring
 - Tools: mypy, pyright
 
 **TypeScript**:

--- a/src/agentready/assessors/code_quality.py
+++ b/src/agentready/assessors/code_quality.py
@@ -265,7 +265,8 @@ class TypeAnnotationsAssessor(BaseAssessor):
         """Check if a Python file is a test file based on path and name conventions."""
         from pathlib import PurePosixPath
 
-        parts = PurePosixPath(file_path).parts
+        normalized = file_path.replace("\\", "/")
+        parts = PurePosixPath(normalized).parts
         name = parts[-1] if parts else ""
         if (
             name.startswith("test_")

--- a/src/agentready/assessors/code_quality.py
+++ b/src/agentready/assessors/code_quality.py
@@ -104,11 +104,16 @@ class TypeAnnotationsAssessor(BaseAssessor):
                 timeout=30,
                 check=True,
             )
-            python_files = [f for f in result.stdout.strip().split("\n") if f]
+            python_files = [
+                f
+                for f in result.stdout.strip().split("\n")
+                if f and not self._is_python_test_file(f)
+            ]
         except Exception:
             python_files = [
                 str(f.relative_to(repository.path))
                 for f in repository.path.rglob("*.py")
+                if not self._is_python_test_file(str(f.relative_to(repository.path)))
             ]
 
         total_functions = 0
@@ -117,7 +122,7 @@ class TypeAnnotationsAssessor(BaseAssessor):
         for file_path in python_files:
             full_path = repository.path / file_path
             try:
-                with open(full_path, "r", encoding="utf-8") as f:
+                with open(full_path, encoding="utf-8") as f:
                     content = f.read()
 
                 # Parse the file with AST
@@ -126,6 +131,8 @@ class TypeAnnotationsAssessor(BaseAssessor):
                 # Walk the AST and count functions with type annotations
                 for node in ast.walk(tree):
                     if isinstance(node, ast.FunctionDef):
+                        if node.name.startswith("test_"):
+                            continue
                         total_functions += 1
                         # Check if function has type annotations
                         # Return type annotation: node.returns is not None
@@ -252,6 +259,21 @@ class TypeAnnotationsAssessor(BaseAssessor):
                 pass
 
         return 0.0, []
+
+    @staticmethod
+    def _is_python_test_file(file_path: str) -> bool:
+        """Check if a Python file is a test file based on path and name conventions."""
+        from pathlib import PurePosixPath
+
+        parts = PurePosixPath(file_path).parts
+        name = parts[-1] if parts else ""
+        if (
+            name.startswith("test_")
+            or name.endswith("_test.py")
+            or name == "conftest.py"
+        ):
+            return True
+        return any(p in ("tests", "test") for p in parts)
 
     def _assess_typescript_types(self, repository: Repository) -> Finding:
         """Assess TypeScript type configuration across all tsconfig.json files.

--- a/tests/unit/test_assessors_code_quality.py
+++ b/tests/unit/test_assessors_code_quality.py
@@ -1611,3 +1611,140 @@ class TestLintSuppressionAttributeMetadata:
         assessors = create_all_assessors()
         ids = [a.attribute_id for a in assessors]
         assert "lint_suppression_density" in ids
+
+
+# =============================================================================
+# TypeAnnotationsAssessor — Python test file/function skipping (#385)
+# =============================================================================
+
+
+def _make_py_repo(tmp_path, languages=None):
+    """Create a test Python repository with git init."""
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+    return Repository(
+        path=tmp_path,
+        name="test-py-repo",
+        url=None,
+        branch="main",
+        commit_hash="abc123",
+        languages=languages or {"Python": 20},
+        total_files=30,
+        total_lines=5000,
+    )
+
+
+def _git_add(tmp_path, *files):
+    """Stage files in git so git ls-files finds them."""
+    for f in files:
+        subprocess.run(
+            ["git", "add", str(f)],
+            cwd=tmp_path,
+            capture_output=True,
+            check=True,
+        )
+
+
+class TestIsTestFile:
+    """Unit tests for _is_python_test_file static method."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "tests/test_foo.py",
+            "test/test_bar.py",
+            "tests/unit/test_baz.py",
+            "src/tests/test_helpers.py",
+            "test_something.py",
+            "foo_test.py",
+            "conftest.py",
+            "tests/conftest.py",
+        ],
+    )
+    def test_identifies_test_files(self, path):
+        assert TypeAnnotationsAssessor._is_python_test_file(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "src/app.py",
+            "src/utils/helpers.py",
+            "main.py",
+            "lib/testing_utils.py",
+        ],
+    )
+    def test_identifies_non_test_files(self, path):
+        assert TypeAnnotationsAssessor._is_python_test_file(path) is False
+
+
+class TestPythonTypeAnnotationsSkipTests:
+    """Integration tests: test files and test functions are excluded from scoring."""
+
+    def test_test_files_excluded_from_scoring(self, tmp_path):
+        """Test files in tests/ should not affect type annotation scoring."""
+        repo = _make_py_repo(tmp_path)
+
+        # Source file: fully typed
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "app.py").write_text("def greet(name: str) -> str:\n    return name\n")
+
+        # Test file: untyped (should be excluded)
+        tests = tmp_path / "tests"
+        tests.mkdir()
+        (tests / "test_app.py").write_text("def test_greet():\n    assert True\n")
+
+        _git_add(tmp_path, src / "app.py", tests / "test_app.py")
+
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor._assess_python_types(repo)
+
+        assert finding.status == "pass"
+        assert "1/1" in finding.evidence[0]
+
+    def test_test_functions_excluded_in_source_files(self, tmp_path):
+        """Test functions (test_*) inside source files should be excluded."""
+        repo = _make_py_repo(tmp_path)
+
+        (tmp_path / "app.py").write_text(
+            "def greet(name: str) -> str:\n"
+            "    return name\n"
+            "\n"
+            "def test_greet():\n"
+            "    assert greet('hi') == 'hi'\n"
+        )
+
+        _git_add(tmp_path, tmp_path / "app.py")
+
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor._assess_python_types(repo)
+
+        assert finding.status == "pass"
+        assert "1/1" in finding.evidence[0]
+
+    def test_untyped_source_still_fails(self, tmp_path):
+        """Non-test source without annotations should still fail."""
+        repo = _make_py_repo(tmp_path)
+
+        (tmp_path / "app.py").write_text("def greet(name):\n    return name\n")
+
+        _git_add(tmp_path, tmp_path / "app.py")
+
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor._assess_python_types(repo)
+
+        assert finding.status == "fail"
+
+    def test_only_test_files_returns_not_applicable(self, tmp_path):
+        """Repo with only test files should return not_applicable."""
+        repo = _make_py_repo(tmp_path)
+
+        tests = tmp_path / "tests"
+        tests.mkdir()
+        (tests / "test_foo.py").write_text("def test_foo():\n    assert True\n")
+
+        _git_add(tmp_path, tests / "test_foo.py")
+
+        assessor = TypeAnnotationsAssessor()
+        finding = assessor._assess_python_types(repo)
+
+        assert finding.status == "not_applicable"

--- a/tests/unit/test_assessors_code_quality.py
+++ b/tests/unit/test_assessors_code_quality.py
@@ -1658,6 +1658,8 @@ class TestIsTestFile:
             "foo_test.py",
             "conftest.py",
             "tests/conftest.py",
+            "tests\\test_foo.py",
+            "test\\test_bar.py",
         ],
     )
     def test_identifies_test_files(self, path):


### PR DESCRIPTION
## Summary

Fixes #385
- Skip test files (`test_*.py`, `*_test.py`, `conftest.py`, `tests/`/`test/` dirs) from Python type annotation scoring
- Skip test functions (`test_*`) inside non-test source files
- Aligns Python behavior with the existing Go `_test.go` exclusion
- Updated `docs/attributes.md` to document the exclusion

## Test plan
- [x] 16 new tests covering file detection and integration behavior
- [x] Linting passes (`black`, `isort`, `ruff`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type-annotation scoring accuracy by excluding Python test files and `test_*` test functions from evaluation.

* **Documentation**
  * Updated “Type Annotations (Static Typing)” criteria to clarify that test files and `test_*` functions are not included in scoring.

* **Tests**
  * Added unit and integration tests covering detection of test file patterns (including Windows-style paths) and verifying assessor behavior for mixed and tests-only repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->