### PR TITLE
docs: clarify parallel job execution in CI example

### DIFF
--- a/src/agentready/assessors/testing.py
+++ b/src/agentready/assessors/testing.py
@@ -1336,7 +1336,7 @@ on:
     branches: [main]
 
 jobs:
-  lint:
+  lint:  # lint and test jobs run in parallel
     name: Lint Code
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Fixes #388

The CI example already demonstrates parallel execution (`lint` and `test` as separate jobs), but this wasn't obvious from reading the remediation output. Added an inline comment to make the parallelization explicit.

## Test plan

- [x] Linting passes
- [x] No logic changes, documentation-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)