### PR TITLE
Improve CyclomaticComplexityAssessor with streaming subprocess and lizard scoring

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -1065,7 +1065,7 @@ A function with 20 branches is hard to reason about whether you're human or an a
 
 #### Measurable Criteria
 
-**Python** (via radon): runs `radon cc` and measures average cyclomatic complexity across all functions. Pass threshold: average < 10.
+**Python** (via radon): analyzes all `.py` files using `radon.complexity.cc_visit()` and computes the average cyclomatic complexity. Pass threshold: average < 10.
 
 **Other languages** (JavaScript, TypeScript, C, C++, Java — via lizard): analyzes all functions using `lizard.analyze()` and computes the average cyclomatic complexity. Pass threshold: average < 10.
 

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -1067,7 +1067,9 @@ A function with 20 branches is hard to reason about whether you're human or an a
 
 **Python** (via radon): runs `radon cc` and measures average cyclomatic complexity across all functions. Pass threshold: average < 10.
 
-**Other languages**: returns `not_applicable` (lizard integration not yet implemented).
+**Other languages** (JavaScript, TypeScript, C, C++, Java — via lizard): analyzes all functions using `lizard.analyze()` and computes the average cyclomatic complexity. Pass threshold: average < 10.
+
+**Go** (via golangci-lint/gocyclo): checks for a configured complexity linter (`gocyclo`, `cyclop`, or `gocognit`) in `.golangci.yml`; if not found, runs `gocyclo -avg` to measure average complexity. Pass threshold: average < 10.
 
 **Pass threshold**: proportional score >= 75 (average complexity well below 10).
 

--- a/src/agentready/assessors/code_quality.py
+++ b/src/agentready/assessors/code_quality.py
@@ -651,20 +651,40 @@ class CyclomaticComplexityAssessor(BaseAssessor):
     def _assess_with_lizard(self, repository: Repository) -> Finding:
         """Assess complexity using lizard (multi-language)."""
         try:
+            last_line = None
             with safe_subprocess_run_stream(
                 ["lizard", str(repository.path)],
                 timeout=60,
             ) as stream:
-                for _line in stream:
-                    pass
+                for line in stream:
+                    last_line = line
 
-                if stream.returncode != 0:
-                    raise MissingToolError(
-                        "lizard", install_command="pip install lizard"
-                    )
+            try:
+                avg_ccn = float(last_line.split()[2])
+            except (AttributeError, IndexError, ValueError):
+                avg_ccn = None
 
-            return Finding.not_applicable(
-                self.attribute, reason="Lizard analysis not fully implemented"
+            if avg_ccn is None:
+                return Finding.not_applicable(
+                    self.attribute, reason="No code to analyze with lizard"
+                )
+
+            score = self.calculate_proportional_score(
+                measured_value=avg_ccn,
+                threshold=10.0,
+                higher_is_better=False,
+            )
+            status = "pass" if score >= 75 else "fail"
+
+            return Finding(
+                attribute=self.attribute,
+                status=status,
+                score=score,
+                measured_value=f"{avg_ccn:.1f}",
+                threshold="<10.0",
+                evidence=[f"Average cyclomatic complexity (lizard): {avg_ccn:.1f}"],
+                remediation=(self._create_remediation() if status == "fail" else None),
+                error_message=None,
             )
 
         except FileNotFoundError:

--- a/src/agentready/assessors/code_quality.py
+++ b/src/agentready/assessors/code_quality.py
@@ -614,7 +614,7 @@ class CyclomaticComplexityAssessor(BaseAssessor):
 
             if stream.returncode != 0:
                 stderr_msg = sanitize_subprocess_error(
-                    Exception(stream.stderr.strip()), repository.path
+                    stream.stderr.strip(), repository.path
                 )
                 raise subprocess.CalledProcessError(
                     stream.returncode, "radon", stderr=stderr_msg
@@ -670,7 +670,7 @@ class CyclomaticComplexityAssessor(BaseAssessor):
 
             if stream.returncode != 0:
                 stderr_msg = sanitize_subprocess_error(
-                    Exception(stream.stderr.strip()), repository.path
+                    stream.stderr.strip(), repository.path
                 )
                 raise subprocess.CalledProcessError(
                     stream.returncode, "lizard", stderr=stderr_msg
@@ -761,7 +761,7 @@ class CyclomaticComplexityAssessor(BaseAssessor):
 
             if stream.returncode != 0:
                 stderr_msg = sanitize_subprocess_error(
-                    Exception(stream.stderr.strip()), repository.path
+                    stream.stderr.strip(), repository.path
                 )
                 raise subprocess.CalledProcessError(
                     stream.returncode, "gocyclo", stderr=stderr_msg

--- a/src/agentready/assessors/code_quality.py
+++ b/src/agentready/assessors/code_quality.py
@@ -616,8 +616,14 @@ class CyclomaticComplexityAssessor(BaseAssessor):
                 stderr_msg = sanitize_subprocess_error(
                     stream.stderr.strip(), repository.path
                 )
+                stdout_msg = sanitize_subprocess_error(
+                    (last_line or "").strip(), repository.path
+                )
                 raise subprocess.CalledProcessError(
-                    stream.returncode, "radon", stderr=stderr_msg
+                    stream.returncode,
+                    "radon",
+                    output=stdout_msg,
+                    stderr=stderr_msg,
                 )
 
             if last_line and last_line.startswith("Average complexity:"):
@@ -672,8 +678,14 @@ class CyclomaticComplexityAssessor(BaseAssessor):
                 stderr_msg = sanitize_subprocess_error(
                     stream.stderr.strip(), repository.path
                 )
+                stdout_msg = sanitize_subprocess_error(
+                    (last_line or "").strip(), repository.path
+                )
                 raise subprocess.CalledProcessError(
-                    stream.returncode, "lizard", stderr=stderr_msg
+                    stream.returncode,
+                    "lizard",
+                    output=stdout_msg,
+                    stderr=stderr_msg,
                 )
 
             try:
@@ -763,8 +775,14 @@ class CyclomaticComplexityAssessor(BaseAssessor):
                 stderr_msg = sanitize_subprocess_error(
                     stream.stderr.strip(), repository.path
                 )
+                stdout_msg = sanitize_subprocess_error(
+                    (last_line or "").strip(), repository.path
+                )
                 raise subprocess.CalledProcessError(
-                    stream.returncode, "gocyclo", stderr=stderr_msg
+                    stream.returncode,
+                    "gocyclo",
+                    output=stdout_msg,
+                    stderr=stderr_msg,
                 )
 
             if last_line and last_line.startswith("Average:"):

--- a/src/agentready/assessors/code_quality.py
+++ b/src/agentready/assessors/code_quality.py
@@ -815,10 +815,18 @@ class CyclomaticComplexityAssessor(BaseAssessor):
                     ),
                     error_message=None,
                 )
+            return Finding.not_applicable(
+                self.attribute, reason="No Go complexity data from gocyclo"
+            )
+
         except FileNotFoundError:
             raise MissingToolError(
                 "gocyclo",
                 install_command="go install github.com/fzipp/gocyclo/cmd/gocyclo@latest",
+            )
+        except Exception as e:
+            return Finding.error(
+                self.attribute, reason=f"Complexity analysis failed: {str(e)}"
             )
 
     def _create_go_complexity_remediation(self) -> Remediation:

--- a/src/agentready/assessors/code_quality.py
+++ b/src/agentready/assessors/code_quality.py
@@ -10,7 +10,7 @@ from ..models.attribute import Attribute
 from ..models.finding import Citation, Finding, Remediation
 from ..models.repository import Repository
 from ..services.scanner import MissingToolError
-from ..utils.subprocess_utils import safe_subprocess_run
+from ..utils.subprocess_utils import safe_subprocess_run, safe_subprocess_run_stream
 from .base import BaseAssessor
 
 logger = logging.getLogger(__name__)
@@ -599,27 +599,19 @@ class CyclomaticComplexityAssessor(BaseAssessor):
     def _assess_python_complexity(self, repository: Repository) -> Finding:
         """Assess Python complexity using radon."""
         try:
-            # Check if radon is available
-            # Security: Use safe_subprocess_run for validation and limits
-            result = safe_subprocess_run(
+            avg_line = None
+            with safe_subprocess_run_stream(
                 ["radon", "cc", str(repository.path), "-s", "-a"],
-                capture_output=True,
-                text=True,
                 timeout=60,
-            )
+            ) as stream:
+                for line in stream:
+                    if "Average complexity:" in line:
+                        avg_line = line
 
-            if result.returncode != 0:
-                raise MissingToolError("radon", install_command="pip install radon")
+                if stream.returncode != 0:
+                    raise MissingToolError("radon", install_command="pip install radon")
 
-            # Parse radon output for average complexity
-            # Output format: "Average complexity: A (5.2)"
-            output = result.stdout
-
-            if "Average complexity:" in output:
-                # Extract average value
-                avg_line = [
-                    line for line in output.split("\n") if "Average complexity:" in line
-                ][0]
+            if avg_line:
                 avg_value = float(avg_line.split("(")[1].split(")")[0])
 
                 score = self.calculate_proportional_score(
@@ -648,10 +640,9 @@ class CyclomaticComplexityAssessor(BaseAssessor):
                 )
 
         except FileNotFoundError:
-            # radon command not found
             raise MissingToolError("radon", install_command="pip install radon")
         except MissingToolError:
-            raise  # Re-raise to be caught by Scanner
+            raise
         except Exception as e:
             return Finding.error(
                 self.attribute, reason=f"Complexity analysis failed: {str(e)}"
@@ -660,25 +651,23 @@ class CyclomaticComplexityAssessor(BaseAssessor):
     def _assess_with_lizard(self, repository: Repository) -> Finding:
         """Assess complexity using lizard (multi-language)."""
         try:
-            # Security: Use safe_subprocess_run for validation and limits
-            result = safe_subprocess_run(
+            with safe_subprocess_run_stream(
                 ["lizard", str(repository.path)],
-                capture_output=True,
-                text=True,
                 timeout=60,
-            )
+            ) as stream:
+                for _line in stream:
+                    pass
 
-            if result.returncode != 0:
-                raise MissingToolError("lizard", install_command="pip install lizard")
+                if stream.returncode != 0:
+                    raise MissingToolError(
+                        "lizard", install_command="pip install lizard"
+                    )
 
-            # Parse lizard output
-            # This is simplified - production code should parse properly
             return Finding.not_applicable(
                 self.attribute, reason="Lizard analysis not fully implemented"
             )
 
         except FileNotFoundError:
-            # lizard command not found
             raise MissingToolError("lizard", install_command="pip install lizard")
         except MissingToolError:
             raise
@@ -694,18 +683,17 @@ class CyclomaticComplexityAssessor(BaseAssessor):
         complexity linters (gocyclo/cyclop) enabled in config.
         """
         try:
-            result = safe_subprocess_run(
+            avg_line = None
+            with safe_subprocess_run_stream(
                 ["gocyclo", "-avg", str(repository.path)],
-                capture_output=True,
-                text=True,
                 timeout=60,
-            )
+            ) as stream:
+                for line in stream:
+                    if "Average" in line:
+                        avg_line = line.strip()
 
-            if result.returncode == 0 and result.stdout.strip():
-                lines = result.stdout.strip().split("\n")
-                avg_line = [line for line in lines if "Average" in line]
-                if avg_line:
-                    avg_value = float(avg_line[0].split()[-1])
+                if stream.returncode == 0 and avg_line:
+                    avg_value = float(avg_line.split()[-1])
 
                     score = self.calculate_proportional_score(
                         measured_value=avg_value,

--- a/src/agentready/assessors/code_quality.py
+++ b/src/agentready/assessors/code_quality.py
@@ -662,11 +662,19 @@ class CyclomaticComplexityAssessor(BaseAssessor):
         try:
             last_line = None
             with safe_subprocess_run_stream(
-                ["lizard", str(repository.path)],
+                ["lizard", "-i", "-1", str(repository.path)],
                 timeout=60,
             ) as stream:
                 for line in stream:
                     last_line = line
+
+            if stream.returncode != 0:
+                stderr_msg = sanitize_subprocess_error(
+                    Exception(stream.stderr.strip()), repository.path
+                )
+                raise subprocess.CalledProcessError(
+                    stream.returncode, "lizard", stderr=stderr_msg
+                )
 
             try:
                 avg_ccn = float(last_line.split()[2])

--- a/src/agentready/assessors/code_quality.py
+++ b/src/agentready/assessors/code_quality.py
@@ -9,6 +9,7 @@ import subprocess
 import tomllib
 
 import lizard
+import radon.complexity
 
 from ..models.attribute import Attribute
 from ..models.finding import Citation, Finding, Remediation
@@ -607,58 +608,40 @@ class CyclomaticComplexityAssessor(BaseAssessor):
     def _assess_python_complexity(self, repository: Repository) -> Finding:
         """Assess Python complexity using radon."""
         try:
-            last_line = None
-            with safe_subprocess_run_stream(
-                ["radon", "cc", str(repository.path), "-s", "-a"],
-                timeout=60,
-            ) as stream:
-                for line in stream:
-                    last_line = line
+            all_blocks = []
+            for py_file in repository.path.rglob("*.py"):
+                try:
+                    code = py_file.read_text(encoding="utf-8")
+                    all_blocks.extend(radon.complexity.cc_visit(code))
+                except (OSError, UnicodeDecodeError, SyntaxError):
+                    continue
 
-            if stream.returncode != 0:
-                stderr_msg = sanitize_subprocess_error(
-                    stream.stderr.strip(), repository.path
-                )
-                stdout_msg = sanitize_subprocess_error(
-                    (last_line or "").strip(), repository.path
-                )
-                raise subprocess.CalledProcessError(
-                    stream.returncode,
-                    "radon",
-                    output=stdout_msg,
-                    stderr=stderr_msg,
-                )
-
-            if last_line and last_line.startswith("Average complexity:"):
-                avg_value = float(last_line.split("(")[1].split(")")[0])
-
-                score = self.calculate_proportional_score(
-                    measured_value=avg_value,
-                    threshold=10.0,
-                    higher_is_better=False,
-                )
-
-                status = "pass" if score >= 75 else "fail"
-
-                return Finding(
-                    attribute=self.attribute,
-                    status=status,
-                    score=score,
-                    measured_value=f"{avg_value:.1f}",
-                    threshold="<10.0",
-                    evidence=[f"Average cyclomatic complexity: {avg_value:.1f}"],
-                    remediation=(
-                        self._create_remediation() if status == "fail" else None
-                    ),
-                    error_message=None,
-                )
-            else:
+            if not all_blocks:
                 return Finding.not_applicable(
                     self.attribute, reason="No Python code to analyze"
                 )
 
-        except FileNotFoundError:
-            raise MissingToolError("radon", install_command="pip install radon")
+            avg_value = radon.complexity.average_complexity(all_blocks)
+
+            score = self.calculate_proportional_score(
+                measured_value=avg_value,
+                threshold=10.0,
+                higher_is_better=False,
+            )
+
+            status = "pass" if score >= 75 else "fail"
+
+            return Finding(
+                attribute=self.attribute,
+                status=status,
+                score=score,
+                measured_value=f"{avg_value:.1f}",
+                threshold="<10.0",
+                evidence=[f"Average cyclomatic complexity: {avg_value:.1f}"],
+                remediation=(self._create_remediation() if status == "fail" else None),
+                error_message=None,
+            )
+
         except Exception as e:
             return Finding.error(
                 self.attribute, reason=f"Complexity analysis failed: {str(e)}"

--- a/src/agentready/assessors/code_quality.py
+++ b/src/agentready/assessors/code_quality.py
@@ -10,6 +10,7 @@ import tomllib
 
 import lizard
 import radon.complexity
+import yaml
 
 from ..models.attribute import Attribute
 from ..models.finding import Citation, Finding, Remediation
@@ -707,10 +708,13 @@ class CyclomaticComplexityAssessor(BaseAssessor):
                 if config_path.exists():
                     try:
                         content = config_path.read_text(encoding="utf-8")
-                        has_complexity = bool(
-                            re.search(r"\b(gocyclo|cyclop|gocognit)\b", content)
-                        )
-                        if has_complexity:
+                        if config_name.endswith(".toml"):
+                            parsed = tomllib.loads(content)
+                        else:
+                            parsed = yaml.safe_load(content) or {}
+                        enabled = parsed.get("linters", {}).get("enable") or []
+                        complexity_linters = {"gocyclo", "cyclop", "gocognit"}
+                        if complexity_linters & set(enabled):
                             rel = config_path.relative_to(repository.path)
                             return Finding(
                                 attribute=self.attribute,
@@ -722,7 +726,7 @@ class CyclomaticComplexityAssessor(BaseAssessor):
                                 remediation=None,
                                 error_message=None,
                             )
-                    except (OSError, UnicodeDecodeError):
+                    except (OSError, UnicodeDecodeError, yaml.YAMLError, ValueError):
                         continue
 
         # Fallback: run gocyclo directly

--- a/src/agentready/assessors/code_quality.py
+++ b/src/agentready/assessors/code_quality.py
@@ -4,13 +4,18 @@ import ast
 import configparser
 import logging
 import re
+import subprocess
 import tomllib
 
 from ..models.attribute import Attribute
 from ..models.finding import Citation, Finding, Remediation
 from ..models.repository import Repository
 from ..services.scanner import MissingToolError
-from ..utils.subprocess_utils import safe_subprocess_run, safe_subprocess_run_stream
+from ..utils.subprocess_utils import (
+    safe_subprocess_run,
+    safe_subprocess_run_stream,
+    sanitize_subprocess_error,
+)
 from .base import BaseAssessor
 
 logger = logging.getLogger(__name__)
@@ -608,8 +613,13 @@ class CyclomaticComplexityAssessor(BaseAssessor):
                     if "Average complexity:" in line:
                         avg_line = line
 
-                if stream.returncode != 0:
-                    raise MissingToolError("radon", install_command="pip install radon")
+            if stream.returncode != 0:
+                stderr_msg = sanitize_subprocess_error(
+                    Exception(stream.stderr.strip()), repository.path
+                )
+                raise subprocess.CalledProcessError(
+                    stream.returncode, "radon", stderr=stderr_msg
+                )
 
             if avg_line:
                 avg_value = float(avg_line.split("(")[1].split(")")[0])

--- a/src/agentready/assessors/code_quality.py
+++ b/src/agentready/assessors/code_quality.py
@@ -8,6 +8,8 @@ import re
 import subprocess
 import tomllib
 
+import lizard
+
 from ..models.attribute import Attribute
 from ..models.finding import Citation, Finding, Remediation
 from ..models.repository import Repository
@@ -665,44 +667,21 @@ class CyclomaticComplexityAssessor(BaseAssessor):
     def _assess_with_lizard(self, repository: Repository) -> Finding:
         """Assess complexity using lizard (multi-language)."""
         try:
-            last_line = None
-            with safe_subprocess_run_stream(
-                [
-                    "lizard",
-                    "-i",
-                    "-1",
-                    "-t",
-                    str(os.cpu_count() or 1),
-                    str(repository.path),
-                ],
-                timeout=60,
-            ) as stream:
-                for line in stream:
-                    last_line = line
+            total_ccn = 0
+            total_funcs = 0
+            for file_info in lizard.analyze(
+                [str(repository.path)], threads=os.cpu_count() or 1
+            ):
+                for func in file_info.function_list:
+                    total_ccn += func.cyclomatic_complexity
+                    total_funcs += 1
 
-            if stream.returncode != 0:
-                stderr_msg = sanitize_subprocess_error(
-                    stream.stderr.strip(), repository.path
-                )
-                stdout_msg = sanitize_subprocess_error(
-                    (last_line or "").strip(), repository.path
-                )
-                raise subprocess.CalledProcessError(
-                    stream.returncode,
-                    "lizard",
-                    output=stdout_msg,
-                    stderr=stderr_msg,
-                )
-
-            try:
-                avg_ccn = float(last_line.split()[2])
-            except (AttributeError, IndexError, ValueError):
-                avg_ccn = None
-
-            if avg_ccn is None:
+            if total_funcs == 0:
                 return Finding.not_applicable(
                     self.attribute, reason="No code to analyze with lizard"
                 )
+
+            avg_ccn = total_ccn / total_funcs
 
             score = self.calculate_proportional_score(
                 measured_value=avg_ccn,
@@ -722,8 +701,6 @@ class CyclomaticComplexityAssessor(BaseAssessor):
                 error_message=None,
             )
 
-        except FileNotFoundError:
-            raise MissingToolError("lizard", install_command="pip install lizard")
         except Exception as e:
             return Finding.error(
                 self.attribute, reason=f"Complexity analysis failed: {str(e)}"

--- a/src/agentready/assessors/code_quality.py
+++ b/src/agentready/assessors/code_quality.py
@@ -3,6 +3,7 @@
 import ast
 import configparser
 import logging
+import os
 import re
 import subprocess
 import tomllib
@@ -666,7 +667,14 @@ class CyclomaticComplexityAssessor(BaseAssessor):
         try:
             last_line = None
             with safe_subprocess_run_stream(
-                ["lizard", "-i", "-1", str(repository.path)],
+                [
+                    "lizard",
+                    "-i",
+                    "-1",
+                    "-t",
+                    str(os.cpu_count() or 1),
+                    str(repository.path),
+                ],
                 timeout=60,
             ) as stream:
                 for line in stream:

--- a/src/agentready/assessors/code_quality.py
+++ b/src/agentready/assessors/code_quality.py
@@ -604,14 +604,13 @@ class CyclomaticComplexityAssessor(BaseAssessor):
     def _assess_python_complexity(self, repository: Repository) -> Finding:
         """Assess Python complexity using radon."""
         try:
-            avg_line = None
+            last_line = None
             with safe_subprocess_run_stream(
                 ["radon", "cc", str(repository.path), "-s", "-a"],
                 timeout=60,
             ) as stream:
                 for line in stream:
-                    if "Average complexity:" in line:
-                        avg_line = line
+                    last_line = line
 
             if stream.returncode != 0:
                 stderr_msg = sanitize_subprocess_error(
@@ -621,8 +620,8 @@ class CyclomaticComplexityAssessor(BaseAssessor):
                     stream.returncode, "radon", stderr=stderr_msg
                 )
 
-            if avg_line:
-                avg_value = float(avg_line.split("(")[1].split(")")[0])
+            if last_line and last_line.startswith("Average complexity:"):
+                avg_value = float(last_line.split("(")[1].split(")")[0])
 
                 score = self.calculate_proportional_score(
                     measured_value=avg_value,

--- a/src/agentready/assessors/code_quality.py
+++ b/src/agentready/assessors/code_quality.py
@@ -707,52 +707,12 @@ class CyclomaticComplexityAssessor(BaseAssessor):
             )
 
     def _assess_go_complexity(self, repository: Repository) -> Finding:
-        """Assess Go complexity using gocyclo or golangci-lint config detection.
+        """Assess Go complexity using golangci-lint config or gocyclo.
 
-        Tries gocyclo first. Falls back to checking if golangci-lint has
-        complexity linters (gocyclo/cyclop) enabled in config.
+        Checks for configured complexity linters first, then falls back
+        to running gocyclo directly.
         """
-        try:
-            avg_line = None
-            with safe_subprocess_run_stream(
-                ["gocyclo", "-avg", str(repository.path)],
-                timeout=60,
-            ) as stream:
-                for line in stream:
-                    if "Average" in line:
-                        avg_line = line.strip()
-
-                if stream.returncode == 0 and avg_line:
-                    avg_value = float(avg_line.split()[-1])
-
-                    score = self.calculate_proportional_score(
-                        measured_value=avg_value,
-                        threshold=10.0,
-                        higher_is_better=False,
-                    )
-                    status = "pass" if score >= 75 else "fail"
-
-                    return Finding(
-                        attribute=self.attribute,
-                        status=status,
-                        score=score,
-                        measured_value=f"{avg_value:.1f}",
-                        threshold="<10.0",
-                        evidence=[
-                            f"Average cyclomatic complexity (gocyclo): {avg_value:.1f}"
-                        ],
-                        remediation=(
-                            self._create_go_complexity_remediation()
-                            if status == "fail"
-                            else None
-                        ),
-                        error_message=None,
-                    )
-        except (FileNotFoundError, Exception):
-            pass
-
-        # Fallback: check if golangci-lint has complexity linters configured
-        # Search root and Go module root directories
+        # Check if golangci-lint has complexity linters configured
         search_dirs = [repository.path] + self._find_go_module_roots(repository)
         for search_dir in search_dirs:
             for config_name in [
@@ -782,10 +742,55 @@ class CyclomaticComplexityAssessor(BaseAssessor):
                     except (OSError, UnicodeDecodeError):
                         continue
 
-        raise MissingToolError(
-            "gocyclo",
-            install_command="go install github.com/fzipp/gocyclo/cmd/gocyclo@latest",
-        )
+        # Fallback: run gocyclo directly
+        try:
+            last_line = None
+            with safe_subprocess_run_stream(
+                ["gocyclo", "-avg", "-top", "1", str(repository.path)],
+                timeout=60,
+            ) as stream:
+                for line in stream:
+                    last_line = line
+
+            if stream.returncode != 0:
+                stderr_msg = sanitize_subprocess_error(
+                    Exception(stream.stderr.strip()), repository.path
+                )
+                raise subprocess.CalledProcessError(
+                    stream.returncode, "gocyclo", stderr=stderr_msg
+                )
+
+            if last_line and last_line.startswith("Average:"):
+                avg_value = float(last_line.split()[-1])
+
+                score = self.calculate_proportional_score(
+                    measured_value=avg_value,
+                    threshold=10.0,
+                    higher_is_better=False,
+                )
+                status = "pass" if score >= 75 else "fail"
+
+                return Finding(
+                    attribute=self.attribute,
+                    status=status,
+                    score=score,
+                    measured_value=f"{avg_value:.1f}",
+                    threshold="<10.0",
+                    evidence=[
+                        f"Average cyclomatic complexity (gocyclo): {avg_value:.1f}"
+                    ],
+                    remediation=(
+                        self._create_go_complexity_remediation()
+                        if status == "fail"
+                        else None
+                    ),
+                    error_message=None,
+                )
+        except FileNotFoundError:
+            raise MissingToolError(
+                "gocyclo",
+                install_command="go install github.com/fzipp/gocyclo/cmd/gocyclo@latest",
+            )
 
     def _create_go_complexity_remediation(self) -> Remediation:
         """Create remediation guidance for Go complexity."""

--- a/src/agentready/assessors/code_quality.py
+++ b/src/agentready/assessors/code_quality.py
@@ -656,8 +656,6 @@ class CyclomaticComplexityAssessor(BaseAssessor):
 
         except FileNotFoundError:
             raise MissingToolError("radon", install_command="pip install radon")
-        except MissingToolError:
-            raise
         except Exception as e:
             return Finding.error(
                 self.attribute, reason=f"Complexity analysis failed: {str(e)}"
@@ -718,8 +716,6 @@ class CyclomaticComplexityAssessor(BaseAssessor):
 
         except FileNotFoundError:
             raise MissingToolError("lizard", install_command="pip install lizard")
-        except MissingToolError:
-            raise
         except Exception as e:
             return Finding.error(
                 self.attribute, reason=f"Complexity analysis failed: {str(e)}"

--- a/src/agentready/utils/__init__.py
+++ b/src/agentready/utils/__init__.py
@@ -9,16 +9,20 @@ from .privacy import (
 )
 from .subprocess_utils import (
     SUBPROCESS_TIMEOUT,
+    StreamingSubprocess,
     SubprocessSecurityError,
     safe_subprocess_run,
+    safe_subprocess_run_stream,
     sanitize_subprocess_error,
     validate_repository_path,
 )
 
 __all__ = [
     "safe_subprocess_run",
+    "safe_subprocess_run_stream",
     "sanitize_subprocess_error",
     "validate_repository_path",
+    "StreamingSubprocess",
     "SubprocessSecurityError",
     "SUBPROCESS_TIMEOUT",
     "sanitize_path",

--- a/src/agentready/utils/subprocess_utils.py
+++ b/src/agentready/utils/subprocess_utils.py
@@ -63,19 +63,21 @@ def validate_repository_path(path: Path) -> Path:
     return resolved
 
 
-def sanitize_subprocess_error(error: Exception, repo_path: Path | None = None) -> str:
+def sanitize_subprocess_error(
+    error: Exception | str, repo_path: Path | None = None
+) -> str:
     """Sanitize error message to prevent information leakage.
 
     Security: Redacts absolute paths, usernames, and sensitive data.
 
     Args:
-        error: Exception to sanitize
+        error: Exception or string to sanitize
         repo_path: Optional repository path to redact
 
     Returns:
         Sanitized error message
     """
-    msg = str(error)
+    msg = error if isinstance(error, str) else str(error)
 
     # Redact absolute paths
     if repo_path:

--- a/src/agentready/utils/subprocess_utils.py
+++ b/src/agentready/utils/subprocess_utils.py
@@ -259,7 +259,7 @@ class StreamingSubprocess:
     def _finalize(self):
         self._process.wait(timeout=10)
         self._stderr_thread.join(timeout=5)
-        self._closed = True
+        self.close()
 
 
 def safe_subprocess_run_stream(

--- a/src/agentready/utils/subprocess_utils.py
+++ b/src/agentready/utils/subprocess_utils.py
@@ -10,6 +10,8 @@ Security features:
 import getpass
 import logging
 import subprocess
+import threading
+import time
 from pathlib import Path
 from typing import Any
 
@@ -98,6 +100,230 @@ def sanitize_subprocess_error(error: Exception, repo_path: Path | None = None) -
         msg = msg[:500] + "... (truncated)"
 
     return msg
+
+
+class StreamingSubprocess:
+    """Iterator/context-manager wrapper around Popen that yields stdout lines.
+
+    Provides the same security guardrails as safe_subprocess_run but streams
+    output incrementally instead of buffering. stderr is accumulated in a
+    background thread and available via the .stderr property after iteration.
+
+    Usage::
+
+        with safe_subprocess_run_stream(["cmd", "arg"], timeout=60) as stream:
+            for line in stream:
+                print(line, end="")
+        print(stream.returncode)
+        print(stream.stderr)
+    """
+
+    def __init__(
+        self,
+        process: subprocess.Popen,
+        timeout: int,
+        max_output_size: int,
+        cwd: Path | None,
+    ):
+        self._process = process
+        self._deadline = time.monotonic() + timeout
+        self._timeout = timeout
+        self._max_output_size = max_output_size
+        self._cwd = cwd
+        self._stderr_bytes_read = 0
+        self._stderr_chunks: list[str] = []
+        self._stderr_error: SubprocessSecurityError | None = None
+        self._closed = False
+        self._timed_out = False
+
+        self._stderr_thread = threading.Thread(target=self._read_stderr, daemon=True)
+        self._stderr_thread.start()
+
+        self._watchdog_thread = threading.Thread(target=self._watchdog, daemon=True)
+        self._watchdog_thread.start()
+
+    @property
+    def returncode(self) -> int | None:
+        return self._process.returncode
+
+    @property
+    def stderr(self) -> str:
+        if self._stderr_thread.is_alive():
+            self._stderr_thread.join(timeout=2)
+        return "".join(self._stderr_chunks)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> str:
+        if self._closed or self._process.stdout is None:
+            raise StopIteration
+
+        if self._timed_out:
+            self._cleanup()
+            raise subprocess.TimeoutExpired(self._process.args, self._timeout)
+
+        if self._stderr_error:
+            self._cleanup()
+            raise self._stderr_error
+
+        line = self._process.stdout.readline()
+
+        if self._timed_out:
+            self._cleanup()
+            raise subprocess.TimeoutExpired(self._process.args, self._timeout)
+
+        if not line:
+            self._finalize()
+            if self._stderr_error:
+                raise self._stderr_error
+            raise StopIteration
+
+        if self._stderr_error:
+            self._cleanup()
+            raise self._stderr_error
+
+        return line
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        self.close()
+
+    def close(self):
+        if self._closed:
+            return
+        self._closed = True
+        self._cleanup()
+
+    def _read_stderr(self):
+        try:
+            for line in self._process.stderr:
+                self._stderr_bytes_read += len(line.encode("utf-8"))
+                if self._stderr_bytes_read > self._max_output_size:
+                    self._stderr_error = SubprocessSecurityError(
+                        f"Subprocess stderr too large: "
+                        f"{self._stderr_bytes_read} bytes "
+                        f"(max: {self._max_output_size})"
+                    )
+                    break
+                self._stderr_chunks.append(line)
+        except (OSError, ValueError):
+            pass
+
+    def _watchdog(self):
+        remaining = self._deadline - time.monotonic()
+        if remaining > 0:
+            try:
+                self._process.wait(timeout=remaining)
+                return
+            except subprocess.TimeoutExpired:
+                pass
+        if self._process.poll() is None:
+            self._timed_out = True
+            sanitized = sanitize_subprocess_error(
+                subprocess.TimeoutExpired(self._process.args, self._timeout),
+                self._cwd,
+            )
+            logger.error(f"Subprocess timeout ({self._timeout}s): {sanitized}")
+            self._terminate()
+
+    def _terminate(self):
+        if self._process.poll() is not None:
+            return
+        self._process.terminate()
+        try:
+            self._process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self._process.kill()
+            self._process.wait()
+
+    def _cleanup(self):
+        self._terminate()
+        if self._process.stdout:
+            try:
+                self._process.stdout.close()
+            except OSError:
+                pass
+        if self._process.stderr:
+            try:
+                self._process.stderr.close()
+            except OSError:
+                pass
+        self._stderr_thread.join(timeout=2)
+        self._watchdog_thread.join(timeout=2)
+
+    def _finalize(self):
+        self._process.wait(timeout=10)
+        self._stderr_thread.join(timeout=5)
+        self._closed = True
+
+
+def safe_subprocess_run_stream(
+    cmd: list[str],
+    cwd: Path | None = None,
+    timeout: int | None = None,
+    max_output_size: int | None = None,
+    **kwargs: Any,
+) -> StreamingSubprocess:
+    """Run subprocess with security guardrails, streaming stdout line-by-line.
+
+    Same security features as safe_subprocess_run, but yields output
+    incrementally via a StreamingSubprocess iterator instead of buffering.
+
+    Args:
+        cmd: Command and arguments (list form, never shell=True)
+        cwd: Working directory (validated if provided)
+        timeout: Timeout in seconds (default: SUBPROCESS_TIMEOUT)
+        max_output_size: Max cumulative bytes per stream (default: MAX_OUTPUT_SIZE)
+        **kwargs: Additional subprocess.Popen() arguments
+
+    Returns:
+        StreamingSubprocess that yields str lines from stdout.
+        Access .returncode and .stderr after iteration completes.
+
+    Raises:
+        SubprocessSecurityError: If shell=True or validation fails
+        subprocess.TimeoutExpired: If command exceeds timeout during iteration
+    """
+    if timeout is None:
+        timeout = kwargs.pop("timeout", SUBPROCESS_TIMEOUT)
+
+    if kwargs.get("shell"):
+        raise SubprocessSecurityError("shell=True is forbidden for security")
+
+    if cwd:
+        cwd_path = Path(cwd)
+        if (cwd_path / ".git").exists() or (cwd_path / ".git").is_file():
+            try:
+                cwd = validate_repository_path(cwd_path)
+            except SubprocessSecurityError:
+                logger.debug(f"Repository validation skipped for: {cwd}")
+
+    if max_output_size is None:
+        max_output_size = MAX_OUTPUT_SIZE
+
+    kwargs.pop("capture_output", None)
+    kwargs.pop("text", None)
+
+    logger.debug(f"Executing streaming subprocess: {' '.join(cmd)} in {cwd}")
+
+    try:
+        process = subprocess.Popen(
+            cmd,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            **kwargs,
+        )
+    except Exception as e:
+        sanitized = sanitize_subprocess_error(e, cwd)
+        logger.error(f"Subprocess error: {sanitized}")
+        raise
+
+    return StreamingSubprocess(process, timeout, max_output_size, cwd)
 
 
 def safe_subprocess_run(

--- a/tests/unit/test_assessors_code_quality.py
+++ b/tests/unit/test_assessors_code_quality.py
@@ -1,9 +1,13 @@
-"""Tests for Python type annotation strict mode detection (ADR A.6)."""
+"""Tests for code quality assessors."""
 
 import json
 import subprocess
+from unittest.mock import patch
 
-from agentready.assessors.code_quality import TypeAnnotationsAssessor
+from agentready.assessors.code_quality import (
+    CyclomaticComplexityAssessor,
+    TypeAnnotationsAssessor,
+)
 from agentready.models.repository import Repository
 
 
@@ -243,3 +247,111 @@ class TestPythonStrictModeDetection:
 
         assert finding.status in ("pass", "fail")
         assert not any("strict mode" in e for e in finding.evidence)
+
+
+# =============================================================================
+# CyclomaticComplexityAssessor — lizard library path
+# =============================================================================
+
+
+class _FakeFunc:
+    """Minimal stand-in for lizard.FunctionInfo."""
+
+    def __init__(self, ccn):
+        self.cyclomatic_complexity = ccn
+
+
+class _FakeFileInfo:
+    """Minimal stand-in for lizard.FileInformation."""
+
+    def __init__(self, funcs):
+        self.function_list = [_FakeFunc(ccn) for ccn in funcs]
+
+
+def _make_js_repo(tmp_path, **kwargs):
+    """Create a test JavaScript repository."""
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+    return Repository(
+        path=tmp_path,
+        name="test-js-repo",
+        url=None,
+        branch="main",
+        commit_hash="abc123",
+        languages=kwargs.get("languages", {"JavaScript": 100}),
+        total_files=10,
+        total_lines=1000,
+    )
+
+
+class TestCyclomaticComplexityLizard:
+    """Test _assess_with_lizard using the lizard library API."""
+
+    def test_low_complexity_passes(self, tmp_path):
+        """Average CCN below threshold produces a pass finding."""
+        repo = _make_js_repo(tmp_path)
+        assessor = CyclomaticComplexityAssessor()
+
+        fake_results = [_FakeFileInfo([2, 3]), _FakeFileInfo([1, 4])]
+        with patch(
+            "agentready.assessors.code_quality.lizard.analyze",
+            return_value=fake_results,
+        ):
+            finding = assessor.assess(repo)
+
+        assert finding.status == "pass"
+        assert finding.score > 0
+        assert "lizard" in finding.evidence[0]
+        assert "2.5" in finding.measured_value
+
+    def test_high_complexity_fails(self, tmp_path):
+        """Average CCN above threshold produces a fail finding."""
+        repo = _make_js_repo(tmp_path)
+        assessor = CyclomaticComplexityAssessor()
+
+        fake_results = [_FakeFileInfo([15, 20, 18])]
+        with patch(
+            "agentready.assessors.code_quality.lizard.analyze",
+            return_value=fake_results,
+        ):
+            finding = assessor.assess(repo)
+
+        assert finding.status == "fail"
+        assert finding.remediation is not None
+
+    def test_no_functions_returns_not_applicable(self, tmp_path):
+        """No functions found produces a not_applicable finding."""
+        repo = _make_js_repo(tmp_path)
+        assessor = CyclomaticComplexityAssessor()
+
+        with patch("agentready.assessors.code_quality.lizard.analyze", return_value=[]):
+            finding = assessor.assess(repo)
+
+        assert finding.status == "not_applicable"
+
+    def test_empty_function_lists_returns_not_applicable(self, tmp_path):
+        """Files with no functions produce a not_applicable finding."""
+        repo = _make_js_repo(tmp_path)
+        assessor = CyclomaticComplexityAssessor()
+
+        fake_results = [_FakeFileInfo([]), _FakeFileInfo([])]
+        with patch(
+            "agentready.assessors.code_quality.lizard.analyze",
+            return_value=fake_results,
+        ):
+            finding = assessor.assess(repo)
+
+        assert finding.status == "not_applicable"
+
+    def test_analyze_exception_returns_error(self, tmp_path):
+        """Exception from lizard.analyze produces an error finding."""
+        repo = _make_js_repo(tmp_path)
+        assessor = CyclomaticComplexityAssessor()
+
+        with patch(
+            "agentready.assessors.code_quality.lizard.analyze",
+            side_effect=RuntimeError("lizard crashed"),
+        ):
+            finding = assessor.assess(repo)
+
+        assert finding.status == "error"
+        assert "lizard crashed" in finding.error_message

--- a/tests/unit/test_assessors_code_quality.py
+++ b/tests/unit/test_assessors_code_quality.py
@@ -355,3 +355,70 @@ class TestCyclomaticComplexityLizard:
 
         assert finding.status == "error"
         assert "lizard crashed" in finding.error_message
+
+
+# =============================================================================
+# CyclomaticComplexityAssessor — radon library path
+# =============================================================================
+
+
+class TestCyclomaticComplexityRadon:
+    """Test _assess_python_complexity using the radon library API."""
+
+    def test_low_complexity_passes(self, tmp_path):
+        """Average complexity below threshold produces a pass finding."""
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+        (tmp_path / "main.py").write_text(
+            "def foo(x):\n    if x:\n        return 1\n    return 0\n"
+        )
+        repo = _make_python_repo(tmp_path)
+
+        assessor = CyclomaticComplexityAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.status == "pass"
+        assert finding.score > 0
+        assert "Average cyclomatic complexity" in finding.evidence[0]
+
+    def test_no_python_files_returns_not_applicable(self, tmp_path):
+        """No Python files produces a not_applicable finding."""
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+        repo = Repository(
+            path=tmp_path,
+            name="test-empty-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Python": 100},
+            total_files=0,
+            total_lines=0,
+        )
+
+        assessor = CyclomaticComplexityAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.status == "not_applicable"
+
+    def test_syntax_error_files_skipped(self, tmp_path):
+        """Files with syntax errors are skipped, not crash the assessor."""
+        repo = _make_python_repo(tmp_path)
+        (tmp_path / "bad.py").write_text("def broken(\n")
+
+        assessor = CyclomaticComplexityAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.status in ("pass", "fail", "not_applicable")
+
+    def test_radon_exception_returns_error(self, tmp_path):
+        """Unexpected exception produces an error finding."""
+        repo = _make_python_repo(tmp_path)
+        assessor = CyclomaticComplexityAssessor()
+
+        with patch(
+            "agentready.assessors.code_quality.radon.complexity.cc_visit",
+            side_effect=RuntimeError("radon crashed"),
+        ):
+            finding = assessor.assess(repo)
+
+        assert finding.status == "error"
+        assert "radon crashed" in finding.error_message

--- a/tests/unit/test_assessors_go.py
+++ b/tests/unit/test_assessors_go.py
@@ -435,6 +435,60 @@ class TestCyclomaticComplexityAssessorGo:
         assert finding.status == "pass"
         assert finding.score == 80.0
 
+    def test_go_commented_linter_not_detected(self, tmp_path):
+        """Commented-out complexity linter does not produce a configured-pass."""
+        from agentready.services.scanner import MissingToolError
+
+        repo = _make_go_repo(tmp_path)
+
+        config = tmp_path / ".golangci.yml"
+        config.write_text(
+            "# gocyclo is too strict for this project\n"
+            "linters:\n"
+            "  enable:\n"
+            "    - govet\n"
+            "    - errcheck\n"
+        )
+
+        assessor = CyclomaticComplexityAssessor()
+        with pytest.raises(MissingToolError):
+            assessor.assess(repo)
+
+    def test_go_disabled_linter_not_detected(self, tmp_path):
+        """Complexity linter in disable list does not produce a configured-pass."""
+        from agentready.services.scanner import MissingToolError
+
+        repo = _make_go_repo(tmp_path)
+
+        config = tmp_path / ".golangci.yml"
+        config.write_text(
+            "linters:\n" "  disable:\n" "    - gocyclo\n" "  enable:\n" "    - govet\n"
+        )
+
+        assessor = CyclomaticComplexityAssessor()
+        with pytest.raises(MissingToolError):
+            assessor.assess(repo)
+
+    def test_go_linter_in_settings_only_not_detected(self, tmp_path):
+        """Complexity linter in linters-settings but not enabled does not pass."""
+        from agentready.services.scanner import MissingToolError
+
+        repo = _make_go_repo(tmp_path)
+
+        config = tmp_path / ".golangci.yml"
+        config.write_text(
+            "linters-settings:\n"
+            "  gocyclo:\n"
+            "    min-complexity: 15\n"
+            "linters:\n"
+            "  enable:\n"
+            "    - govet\n"
+        )
+
+        assessor = CyclomaticComplexityAssessor()
+        with pytest.raises(MissingToolError):
+            assessor.assess(repo)
+
     def test_go_without_tools_raises_missing_tool(self, tmp_path):
         """Go repo without gocyclo or golangci-lint config raises MissingToolError."""
         from agentready.services.scanner import MissingToolError

--- a/tests/unit/test_assessors_go.py
+++ b/tests/unit/test_assessors_go.py
@@ -1,6 +1,7 @@
 """Tests for Go language support across all assessors."""
 
 import subprocess
+from unittest.mock import patch
 
 import pytest
 
@@ -451,8 +452,12 @@ class TestCyclomaticComplexityAssessorGo:
         )
 
         assessor = CyclomaticComplexityAssessor()
-        with pytest.raises(MissingToolError):
-            assessor.assess(repo)
+        with patch(
+            "agentready.assessors.code_quality.safe_subprocess_run_stream",
+            side_effect=FileNotFoundError,
+        ):
+            with pytest.raises(MissingToolError):
+                assessor.assess(repo)
 
     def test_go_disabled_linter_not_detected(self, tmp_path):
         """Complexity linter in disable list does not produce a configured-pass."""
@@ -466,8 +471,12 @@ class TestCyclomaticComplexityAssessorGo:
         )
 
         assessor = CyclomaticComplexityAssessor()
-        with pytest.raises(MissingToolError):
-            assessor.assess(repo)
+        with patch(
+            "agentready.assessors.code_quality.safe_subprocess_run_stream",
+            side_effect=FileNotFoundError,
+        ):
+            with pytest.raises(MissingToolError):
+                assessor.assess(repo)
 
     def test_go_linter_in_settings_only_not_detected(self, tmp_path):
         """Complexity linter in linters-settings but not enabled does not pass."""
@@ -486,8 +495,12 @@ class TestCyclomaticComplexityAssessorGo:
         )
 
         assessor = CyclomaticComplexityAssessor()
-        with pytest.raises(MissingToolError):
-            assessor.assess(repo)
+        with patch(
+            "agentready.assessors.code_quality.safe_subprocess_run_stream",
+            side_effect=FileNotFoundError,
+        ):
+            with pytest.raises(MissingToolError):
+                assessor.assess(repo)
 
     def test_go_without_tools_raises_missing_tool(self, tmp_path):
         """Go repo without gocyclo or golangci-lint config raises MissingToolError."""

--- a/tests/unit/utils/test_subprocess_utils.py
+++ b/tests/unit/utils/test_subprocess_utils.py
@@ -11,6 +11,7 @@ from agentready.utils.subprocess_utils import (
     SUBPROCESS_TIMEOUT,
     SubprocessSecurityError,
     safe_subprocess_run,
+    safe_subprocess_run_stream,
     sanitize_subprocess_error,
     validate_repository_path,
 )
@@ -396,6 +397,147 @@ class TestSafeSubprocessRun:
         )
         assert result.returncode == 0
         assert isinstance(result.stdout, str)
+
+
+class TestSafeSubprocessRunStream:
+    """Test streaming subprocess execution."""
+
+    def test_stream_basic_output(self):
+        """Test basic line-by-line streaming."""
+        with safe_subprocess_run_stream(["seq", "5"]) as stream:
+            lines = list(stream)
+        assert lines == ["1\n", "2\n", "3\n", "4\n", "5\n"]
+        assert stream.returncode == 0
+
+    def test_stream_returncode_success(self):
+        """Test returncode is 0 on success."""
+        with safe_subprocess_run_stream(["true"]) as stream:
+            list(stream)
+        assert stream.returncode == 0
+
+    def test_stream_returncode_failure(self):
+        """Test returncode is non-zero on failure."""
+        with safe_subprocess_run_stream(["false"]) as stream:
+            list(stream)
+        assert stream.returncode != 0
+
+    def test_stream_stderr_accumulation(self):
+        """Test stderr is accumulated separately."""
+        with safe_subprocess_run_stream(
+            ["bash", "-c", "echo out; echo err >&2"]
+        ) as stream:
+            stdout_lines = list(stream)
+        assert "out\n" in stdout_lines
+        assert "err\n" in stream.stderr
+
+    def test_stream_shell_forbidden(self):
+        """Test that shell=True is blocked."""
+        with pytest.raises(SubprocessSecurityError, match="shell=True is forbidden"):
+            safe_subprocess_run_stream(["echo test"], shell=True)
+
+    def test_stream_timeout(self):
+        """Test timeout enforcement during streaming."""
+        with pytest.raises(subprocess.TimeoutExpired):
+            with safe_subprocess_run_stream(["sleep", "10"], timeout=1) as stream:
+                list(stream)
+
+    def test_stream_stderr_size_limit(self):
+        """Test stderr size limit enforcement."""
+        with pytest.raises(SubprocessSecurityError, match="stderr too large"):
+            with safe_subprocess_run_stream(
+                ["bash", "-c", "head -c 200 /dev/zero >&2"],
+                max_output_size=100,
+            ) as stream:
+                for _ in stream:
+                    pass
+
+    def test_stream_context_manager_cleanup(self):
+        """Test process is cleaned up when exiting context manager."""
+        stream = safe_subprocess_run_stream(["sleep", "60"], timeout=60)
+        with stream:
+            pass
+        assert stream._process.poll() is not None
+
+    def test_stream_early_close(self):
+        """Test explicit close during iteration."""
+        with safe_subprocess_run_stream(["yes"], timeout=10) as stream:
+            next(stream)
+            stream.close()
+        assert stream._process.poll() is not None
+
+    def test_stream_break_from_loop(self):
+        """Test breaking from for-loop cleans up process."""
+        with safe_subprocess_run_stream(["yes"], timeout=10) as stream:
+            for line in stream:
+                break
+        assert stream._process.poll() is not None
+
+    def test_stream_cwd_validation(self, tmp_path):
+        """Test cwd path validation for git repos."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+
+        with safe_subprocess_run_stream(["echo", "test"], cwd=repo) as stream:
+            lines = list(stream)
+        assert lines == ["test\n"]
+        assert stream.returncode == 0
+
+    def test_stream_kwargs_passthrough(self):
+        """Test additional kwargs are passed to Popen."""
+        with safe_subprocess_run_stream(
+            ["echo", "test"],
+            env={"TEST_VAR": "value", "PATH": "/usr/bin:/bin"},
+        ) as stream:
+            lines = list(stream)
+        assert lines == ["test\n"]
+
+    def test_stream_strips_capture_output_kwarg(self):
+        """Test capture_output kwarg is silently stripped."""
+        with safe_subprocess_run_stream(
+            ["echo", "test"], capture_output=True
+        ) as stream:
+            lines = list(stream)
+        assert lines == ["test\n"]
+
+    def test_stream_strips_text_kwarg(self):
+        """Test text kwarg is silently stripped."""
+        with safe_subprocess_run_stream(["echo", "test"], text=False) as stream:
+            lines = list(stream)
+        assert lines == ["test\n"]
+        assert isinstance(lines[0], str)
+
+    def test_stream_command_not_found(self):
+        """Test handling of command not found."""
+        with pytest.raises(FileNotFoundError):
+            safe_subprocess_run_stream(["nonexistent-command-12345"])
+
+    def test_stream_default_timeout(self):
+        """Test default timeout constant is used."""
+        with safe_subprocess_run_stream(["echo", "test"]) as stream:
+            list(stream)
+        assert stream.returncode == 0
+
+    def test_stream_empty_output(self):
+        """Test command that produces no stdout."""
+        with safe_subprocess_run_stream(["true"]) as stream:
+            lines = list(stream)
+        assert lines == []
+        assert stream.returncode == 0
+
+    def test_stream_close_idempotent(self):
+        """Test calling close multiple times is safe."""
+        with safe_subprocess_run_stream(["echo", "test"]) as stream:
+            list(stream)
+        stream.close()
+        stream.close()
+
+    def test_stream_iteration_after_close(self):
+        """Test iterating after close raises StopIteration."""
+        stream = safe_subprocess_run_stream(["echo", "test"])
+        stream.close()
+        with pytest.raises(StopIteration):
+            next(stream)
 
 
 class TestSecurityConstants:


### PR DESCRIPTION
## Description

Summary

- Add StreamingSubprocess / safe_subprocess_run_stream() to stream subprocess stdout line-by-line instead of buffering, with background stderr accumulation, watchdog timeout, and the same security guardrails as safe_subprocess_run()
- Migrate radon, lizard, and gocyclo execution in CyclomaticComplexityAssessor to use streaming, reducing peak memory on large repos
- Implement actual lizard output parsing and scoring (was previously a not_applicable stub), using -i -1 (all languages) and -t N (parallel threads matching CPU count)
- Reorder Go complexity assessment to check golangci-lint config before falling back to gocyclo (avoids running a binary that may not be installed)
- Allow sanitize_subprocess_error() to accept raw strings in addition to exceptions
- Remove redundant except MissingToolError: raise blocks
- Raise CalledProcessError (with sanitized stdout/stderr) instead of MissingToolError on non-zero return codes, so tool-missing vs tool-failed errors are distinguished
- Parse radon average from the last output line only instead of scanning the full buffer

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test coverage improvement

## Changes Made

<!-- Detailed list of changes made in this PR -->

- chore: remove redundant except MissingToolError re-raises
- feat: include sanitized stdout in CyclomaticComplexityAssessor errors
- refactor: allow sanitize_subprocess_error to accept strings directly
- fix: add -i -1 flag and returncode check to lizard assessment
- refactor: parse radon average from last line only
- refactor: improve _assess_go_complexity
- fix: replace MissingToolError with CalledProcessError for radon failures
- feat: implement lizard output parsing and remove returncode check
- refactor: use safe_subprocess_run_stream in CyclomaticComplexityAssessor
- feat: add safe_subprocess_run_stream for streaming subprocess output

## Testing

Test plan

- [x] pytest tests/unit/utils/test_subprocess_utils.py — 18 new tests covering streaming basics, timeout, stderr accumulation, size limits, cleanup, early close, idempotent close, and kwarg stripping
- [x] pytest tests/unit/test_assessors_code_quality.py — existing cyclomatic complexity tests still pass
- [x] pytest --cov=src/agentready — verify coverage for new code
- [x] Run agentready assess against a real repo with Python, Go, and multi-language files to validate radon/lizard/gocyclo scoring end-to-end

- [x] Unit tests pass (`pytest`)
- [x] Integration tests pass
- [x] Manual testing performed
- [x] No new warnings or errors

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved cyclomatic complexity analysis for Python and Go by computing results in-process and aggregating averages more reliably.
  * Enhanced Go linter configuration detection and refined the fallback behavior when complexity tooling is unavailable.
  * Added safer, streaming subprocess execution with better command handling and error sanitization.
* **Documentation**
  * Updated “Cyclomatic Complexity Limits” criteria to reflect the revised measurement approach for Python, other languages, and Go.
* **Tests**
  * Added unit tests for streaming subprocess behavior and cyclomatic complexity coverage across backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->