### PR TITLE
feat: add adr_frontmatter_completeness assessor with central ADR repo support

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -1100,12 +1100,13 @@ radon cc src/ -s -nb
 
 **Structured Logging** (`structured_logging`, 1%) — JSON logs with consistent fields
 **OpenAPI/Swagger Specs** (`openapi_specs`, 2%) — Machine-readable API docs
-**Progressive Disclosure** (`progressive_disclosure`, 2%) — Path-scoped rules, skills for focused context (moved from T4)
+**Progressive Disclosure** (`progressive_disclosure`, 1%) — Path-scoped rules, skills for focused context (moved from T4)
+**ADR Frontmatter Completeness** (`adr_frontmatter_completeness`, 2%) — Structured YAML frontmatter in ADR files enabling automated filtering by status and applicability
 ### Architecture Decision Records
 
 **ID**: `architecture_decisions`
 **Tier**: Tier 3
-**Weight**: 2%
+**Weight**: 1%
 **Category**: Documentation Standards
 **Status**: ✅ Implemented
 
@@ -1163,6 +1164,63 @@ EOF
 ```
 
 **Tools**: [adr-tools](https://github.com/npryce/adr-tools), [log4brains](https://github.com/thomvaill/log4brains)
+
+---
+
+### ADR Frontmatter Completeness
+
+**ID**: `adr_frontmatter_completeness`
+**Tier**: Tier 3
+**Weight**: 2%
+**Category**: Documentation Standards
+**Status**: ✅ Implemented
+
+#### Definition
+
+Scores repositories on whether ADR files contain structured YAML frontmatter with the required `status` and `applies_to` fields. Machine-readable frontmatter enables automated tooling (and AI agents) to filter ADRs by lifecycle state and applicability to a given service.
+
+#### Why It Matters
+
+ADRs without frontmatter are human-readable only. With `status` and `applies_to`, agents can determine whether a decision is still active and whether it applies to the repository they are working in — turning static documents into queryable knowledge.
+
+#### Measurable Criteria
+
+| Coverage | Score | Status |
+|----------|-------|--------|
+| ≥80% of ADR files have valid frontmatter | 100 | pass |
+| 50–79% have valid frontmatter | 60 | fail (partial) |
+| <50% have valid frontmatter | 0 | fail |
+| No ADR files found | — | skipped |
+
+A frontmatter block is **valid** when:
+- `status` is present and a non-empty string (any lifecycle value accepted, e.g. Proposed, Accepted, Implemented, Deprecated)
+- `applies_to` is present and either a non-empty string or a list of non-empty strings (wildcards `"*"` are supported)
+
+**Central ADR repository support**: repos that maintain ADRs in a shared central repository can configure `adr_source` in `.agentready-config.yaml` to point the assessor at the local clone. ADRs are then filtered by `applies_to` matching the assessed repo's name.
+
+```yaml
+# .agentready-config.yaml
+adr_source:
+  repo: /path/to/local/clone   # locally cloned central ADR repo
+  path: ADR                    # relative path within that repo
+```
+
+#### Remediation
+
+Add a YAML frontmatter block to the top of each ADR file:
+
+```markdown
+---
+status: Accepted
+applies_to: my-service   # or "*" for org-wide, or a list of service names
+---
+# ADR 0001: Title
+...
+```
+
+Aim for ≥80% of ADR files to have valid frontmatter.
+
+> **Note — config auto-discovery**: AgentReady does not yet auto-discover `.agentready-config.yaml` from the assessed repo's root (tracked in [#144](https://github.com/ambient-code/agentready/issues/144)). The `--config` flag must be passed explicitly when using the central ADR source feature. A repo maintainer committing `.agentready-config.yaml` to the repo root will not have it picked up automatically until #144 is resolved.
 
 ---
 

--- a/src/agentready/assessors/__init__.py
+++ b/src/agentready/assessors/__init__.py
@@ -6,6 +6,7 @@ across CLI modules (main.py, assess_batch.py, demo.py).
 v2.0.0: Updated with evidence-based rebalancing (ETH Zurich, Red Hat, Anthropic).
 """
 
+from .adr_frontmatter import AdrFrontmatterAssessor
 from .base import BaseAssessor
 from .code_quality import (
     CyclomaticComplexityAssessor,
@@ -54,7 +55,12 @@ from .testing import (
 )
 from .verification import SingleFileVerificationAssessor
 
-__all__ = ["create_all_assessors", "BaseAssessor", "LockFilesAssessor"]
+__all__ = [
+    "create_all_assessors",
+    "BaseAssessor",
+    "LockFilesAssessor",
+    "AdrFrontmatterAssessor",
+]
 
 
 def create_all_assessors() -> list[BaseAssessor]:
@@ -91,12 +97,13 @@ def create_all_assessors() -> list[BaseAssessor]:
         DesignIntentAssessor(),  # 3% (moved from T3)
         DbtDataTestsAssessor(),  # dbt conditional
         DbtProjectStructureAssessor(),  # dbt conditional
-        # Tier 3 Important — 13% total (7 attributes)
-        ArchitectureDecisionsAssessor(),  # 2%
+        # Tier 3 Important — 13% total (8 attributes)
+        ArchitectureDecisionsAssessor(),  # 1%
+        AdrFrontmatterAssessor(),  # 2% (2.4 - ADR Frontmatter Completeness)
         OpenAPISpecsAssessor(),  # 2%
         CyclomaticComplexityAssessor(),  # 2%
         StructuredLoggingAssessor(),  # 1%
-        ProgressiveDisclosureAssessor(),  # 2% (moved from T4)
+        ProgressiveDisclosureAssessor(),  # 1% (moved from T4)
         ArchitecturalBoundaryAssessor(),  # 2% (ADR B.1)
         ThreatModelAssessor(),  # 2% (ADR B.2)
         # Tier 4 Advanced — 2% total (2 attributes, 1% each)

--- a/src/agentready/assessors/_adr_utils.py
+++ b/src/agentready/assessors/_adr_utils.py
@@ -1,0 +1,29 @@
+"""Shared helpers for ADR assessor modules.
+
+Extracted to avoid a circular import between adr_frontmatter and adr_sources.
+"""
+
+import yaml
+
+
+def parse_frontmatter(content: str) -> dict | None:
+    """Extract YAML frontmatter from a markdown string.
+
+    Returns a dict if a valid frontmatter block is found, an empty dict
+    for an empty block, or None if no block exists, the YAML is invalid,
+    or the parsed value is not a mapping (e.g. a scalar or list).
+    """
+    if not content.startswith("---"):
+        return None
+    end = content.find("---", 3)
+    if end == -1:
+        return None
+    try:
+        result = yaml.safe_load(content[3:end])
+        if result is None:
+            return {}
+        if not isinstance(result, dict):
+            return None
+        return result
+    except yaml.YAMLError:
+        return None

--- a/src/agentready/assessors/adr_frontmatter.py
+++ b/src/agentready/assessors/adr_frontmatter.py
@@ -1,0 +1,291 @@
+"""ADR Frontmatter Completeness assessor.
+
+Scores repositories on whether ADR files contain structured YAML
+frontmatter with required fields (status + applies_to).
+"""
+
+from pathlib import Path
+
+from ..models.attribute import Attribute
+from ..models.config import AdrSourceConfig
+from ..models.finding import Finding, Remediation
+from ..models.repository import Repository
+from ._adr_utils import parse_frontmatter
+from .adr_sources import CentralAdrSource, LocalAdrSource
+from .base import BaseAssessor
+
+# VALID_STATUSES is kept as a reference for documentation and upstream tooling;
+# it is no longer used to gate completeness scoring so that unfamiliar lifecycle
+# values (e.g. project-specific conventions) are not incorrectly rejected.
+# Title Case entries follow MADR convention; lowercase entries follow adr-tools convention.
+VALID_STATUSES: frozenset[str] = frozenset(
+    [
+        # MADR core
+        "Proposed",
+        "Accepted",
+        "Implementable",
+        "Implemented",
+        "Replaced",
+        "Deprecated",
+        "Superseded",
+        "Approved",
+        # adr-tools lowercase
+        "active",
+        "superseded",
+        "draft",
+    ]
+)
+
+
+def classify_adr_file(path: Path) -> str:
+    """Classify a single ADR markdown file.
+
+    Returns one of:
+    - "valid"          — frontmatter present, status + applies_to valid
+    - "incomplete"     — frontmatter present but field(s) missing/invalid
+    - "no_frontmatter" — no leading --- block
+    """
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return "no_frontmatter"
+
+    fm = parse_frontmatter(content)
+    if fm is None:
+        return "no_frontmatter"
+
+    status = fm.get("status")
+    applies_to = fm.get("applies_to")
+
+    # status must be present and a non-empty string; we do not restrict to VALID_STATUSES
+    # so that project-specific lifecycle values are not rejected.
+    if not status or not isinstance(status, str):
+        return "incomplete"
+
+    # applies_to must be present: a non-empty string, or a list whose every
+    # item is a non-empty string (matching the contract of _applies_to_matches).
+    if applies_to is None:
+        return "incomplete"
+    if not isinstance(applies_to, (str, list)):
+        return "incomplete"
+    if isinstance(applies_to, str) and not applies_to.strip():
+        return "incomplete"
+    if isinstance(applies_to, list):
+        if not applies_to:
+            return "incomplete"
+        if not all(isinstance(item, str) and item.strip() for item in applies_to):
+            return "incomplete"
+
+    return "valid"
+
+
+def score_from_coverage(valid: int, total: int) -> tuple[str, float]:
+    """Compute (status_label, score) from valid/total ADR counts.
+
+    Uses a three-band step function (0 / 60 / 100) rather than
+    BaseAssessor.calculate_proportional_score(), which does linear
+    interpolation.  The discrete bands are intentional: frontmatter
+    compliance is a threshold-based quality gate, not a continuous metric.
+
+    Args:
+        valid: Number of valid ADRs.
+        total: Total number of ADRs (valid + incomplete + no_frontmatter).
+
+    Returns:
+        Tuple of (status_label, score) where status_label is one of
+        "pass", "partial", or "fail", and score is 0.0, 60.0, or 100.0.
+    """
+    if total == 0:
+        return ("pass", 100.0)
+    coverage = valid / total
+    if coverage >= 0.80:
+        return ("pass", 100.0)
+    elif coverage >= 0.50:
+        return ("partial", 60.0)
+    else:
+        return ("fail", 0.0)
+
+
+class AdrFrontmatterAssessor(BaseAssessor):
+    """Assesses ADR frontmatter completeness (status + applies_to fields).
+
+    Tier 3 Important (2% weight). Structured frontmatter enables automated
+    tooling to filter ADRs by applicability, status, and lifecycle stage.
+    """
+
+    @property
+    def attribute_id(self) -> str:
+        """Unique identifier used to register and look up this assessor."""
+        return "adr_frontmatter_completeness"
+
+    @property
+    def tier(self) -> int:
+        """Tier 3 — Important."""
+        return 3
+
+    @property
+    def attribute(self) -> Attribute:
+        """Attribute metadata including name, category, and default weight."""
+        return Attribute(
+            id=self.attribute_id,
+            name="ADR Frontmatter Completeness",
+            category="Documentation Standards",
+            tier=self.tier,
+            description=(
+                "ADR files contain structured YAML frontmatter with required "
+                "status and applies_to fields"
+            ),
+            criteria="≥80% of ADR files have valid frontmatter",
+            default_weight=0.02,
+        )
+
+    def assess(self, repository: Repository) -> Finding:
+        """Score ADR frontmatter completeness using LocalAdrSource or CentralAdrSource.
+
+        If repository.config.adr_source is set, tries CentralAdrSource first.
+        A None return from _assess_central means no central ADRs matched this
+        repo — fall through to _assess_local so local ADRs are still scored.
+        A Finding return (pass, fail, or skipped) is used directly.
+
+        Returns skipped if no ADR files are found anywhere.
+        """
+        adr_source_config = (
+            repository.config.adr_source if repository.config is not None else None
+        )
+
+        if adr_source_config is not None:
+            central_result = self._assess_central(repository, adr_source_config)
+            if central_result is not None:
+                return central_result
+            # None → no central ADRs match this repo; fall through to local scan
+
+        return self._assess_local(repository)
+
+    def _assess_local(self, repository: Repository) -> Finding:
+        """Assess using LocalAdrSource (default path)."""
+        source = LocalAdrSource()
+        adr_dir = source.find_adr_dir(repository)
+
+        if adr_dir is None:
+            return Finding.skipped(
+                self.attribute,
+                "No ADR files found in standard locations",
+            )
+
+        adr_files = source.get_adr_files(adr_dir)
+        return self._score_files(adr_files, adr_dir)
+
+    def _assess_central(
+        self, repository: Repository, config: AdrSourceConfig
+    ) -> "Finding | None":
+        """Assess using CentralAdrSource (central repo path).
+
+        Returns:
+            Finding (pass/fail/skipped): use directly — repo is unconfigured,
+                path/subdir is unreachable, or matching ADRs were scored.
+            None: central repo is reachable but no ADRs match this repo;
+                caller should fall through to _assess_local.
+        """
+        local_path = Path(config.repo)
+        adr_path = config.path
+
+        if not local_path.exists():
+            return Finding.skipped(
+                self.attribute,
+                f"Central ADR repo not found at {local_path}",
+            )
+
+        source = CentralAdrSource(local_path=local_path, adr_path=adr_path)
+
+        if not source.adr_dir.is_dir():
+            return Finding.skipped(
+                self.attribute,
+                f"Central ADR subdirectory missing: {source.adr_dir}",
+            )
+
+        try:
+            total_in_central = sum(
+                1 for p in source.adr_dir.iterdir() if p.suffix == ".md" and p.is_file()
+            )
+        except OSError:
+            return Finding.skipped(
+                self.attribute,
+                f"Central ADR directory is not readable: {source.adr_dir}",
+            )
+
+        matched_files = source.get_matching_adr_files(repository.name)
+
+        if not matched_files:
+            # No central match — caller falls through to local scan
+            return None
+
+        extra_evidence = [
+            f"ADR source: {source.adr_dir}/ (central repo)",
+            (
+                f"Filtered by applies_to: {repository.name} "
+                f"({len(matched_files)} of {total_in_central} total ADRs matched)"
+            ),
+        ]
+        return self._score_files(
+            matched_files, source.adr_dir, extra_evidence=extra_evidence
+        )
+
+    def _score_files(
+        self,
+        adr_files: list[Path],
+        adr_dir: Path,
+        extra_evidence: list[str] | None = None,
+    ) -> Finding:
+        """Classify files, compute coverage, and build Finding."""
+        counts: dict[str, int] = {"valid": 0, "incomplete": 0, "no_frontmatter": 0}
+        for f in adr_files:
+            label = classify_adr_file(f)
+            counts[label] += 1
+
+        total = len(adr_files)
+        valid = counts["valid"]
+        status_label, score = score_from_coverage(valid, total)
+
+        pct = int(valid / total * 100) if total > 0 else 100
+        measured_value = f"{valid}/{total} ADRs valid ({pct}%)"
+        evidence = [
+            f"ADR location: {adr_dir}",
+            (
+                f"{valid} valid, {counts['incomplete']} incomplete, "
+                f"{counts['no_frontmatter']} no-frontmatter ({total} total)"
+            ),
+        ]
+        if extra_evidence:
+            evidence.extend(extra_evidence)
+
+        remediation = None
+        if status_label != "pass":
+            remediation = Remediation(
+                summary="Add YAML frontmatter with status and applies_to to all ADR files",
+                steps=[
+                    "Add a frontmatter block at the top of each ADR file",
+                    "Include 'status' with a meaningful lifecycle value (e.g. Proposed, Accepted, Implemented, Deprecated — any non-empty string is accepted)",
+                    "Include 'applies_to' (repo name, list of repos, or '*' for all)",
+                    "Aim for ≥80% of ADRs to have valid frontmatter",
+                ],
+                tools=[],
+                commands=[],
+                examples=[
+                    "---\nstatus: Implemented\napplies_to: my-service\n---\n# ADR 0001: ..."
+                ],
+                citations=[],
+            )
+
+        # "partial" is reported as "fail" with score=60 (Finding requires pass/fail)
+        finding_status = "pass" if status_label == "pass" else "fail"
+
+        return Finding(
+            attribute=self.attribute,
+            status=finding_status,
+            score=score,
+            measured_value=measured_value,
+            threshold="≥80% valid ADRs",
+            evidence=evidence,
+            remediation=remediation,
+            error_message=None,
+        )

--- a/src/agentready/assessors/adr_sources.py
+++ b/src/agentready/assessors/adr_sources.py
@@ -1,0 +1,170 @@
+"""ADR source abstractions for AdrFrontmatterAssessor.
+
+LocalAdrSource scans the assessed repo's filesystem.
+CentralAdrSource reads from a locally cloned central ADR repository,
+filtering by applies_to.
+"""
+
+from pathlib import Path
+
+from ..models.repository import Repository
+from ._adr_utils import parse_frontmatter
+
+# Priority-ordered candidate directories for LocalAdrSource.
+_LOCAL_ADR_CANDIDATES: list[str] = [
+    "ADR",  # Uppercase — Konflux style, first priority
+    "docs/adr",
+    "adr",
+    "decisions",
+    "doc/adr",
+]
+
+
+class LocalAdrSource:
+    """Scan the assessed repo filesystem for ADR files.
+
+    Searches candidate directories in priority order and returns the
+    first one that contains at least one .md file.
+    """
+
+    def find_adr_dir(self, repository: Repository) -> Path | None:
+        """Return the first candidate directory containing .md files.
+
+        Args:
+            repository: Repository being assessed.
+
+        Returns:
+            Path to the ADR directory, or None if not found.
+        """
+        for candidate in _LOCAL_ADR_CANDIDATES:
+            path = repository.path / candidate
+            if path.is_dir() and self.get_adr_files(path):
+                return path
+        return None
+
+    def get_adr_files(self, adr_dir: Path) -> list[Path]:
+        """Return all .md files directly in adr_dir (non-recursive).
+
+        Args:
+            adr_dir: Directory to search.
+
+        Returns:
+            Sorted list of .md Path objects (empty if none found).
+        """
+        try:
+            return sorted(
+                p for p in adr_dir.iterdir() if p.suffix == ".md" and p.is_file()
+            )
+        except OSError:
+            return []
+
+
+def _applies_to_matches(applies_to: str | list, repo_name: str) -> bool:
+    """Check whether an applies_to value matches the given repo_name.
+
+    Matching rules:
+    - "*" matches everything.
+    - A string matches if it equals repo_name, or repo_name ends with /<value>.
+    - A list matches if any element matches by the above rules.
+    """
+    if isinstance(applies_to, list):
+        return any(_applies_to_matches(item, repo_name) for item in applies_to)
+    if not isinstance(applies_to, str):
+        return False
+    if applies_to == "*":
+        return True
+    if applies_to == repo_name:
+        return True
+    # Full org/repo in applies_to ("org/repo") matched by short name ("repo")
+    if applies_to.endswith(f"/{repo_name}"):
+        return True
+    # Short name in applies_to ("repo") matched by full name ("org/repo")
+    if repo_name.endswith(f"/{applies_to}"):
+        return True
+    return False
+
+
+class CentralAdrSource:
+    """Scan a locally cloned central ADR repo, filtering by applies_to.
+
+    The central repo is expected to be pre-cloned at local_path.
+    No network access is performed.
+
+    Args:
+        local_path: Root directory of the cloned central ADR repository.
+        adr_path: Relative path within local_path containing ADR .md files
+                  (e.g. "ADR" or "ADR/"). Trailing slashes are stripped.
+    """
+
+    def __init__(self, local_path: Path, adr_path: str) -> None:
+        """Initialise CentralAdrSource.
+
+        Args:
+            local_path: Root directory of the cloned central ADR repository.
+            adr_path: Relative path within local_path containing ADR .md files.
+
+        Raises:
+            ValueError: If adr_path is absolute or contains path-traversal ('..').
+        """
+        stripped = adr_path.rstrip("/")
+        if not stripped:
+            raise ValueError(
+                f"adr_path must be a non-empty relative subpath, got: {adr_path!r}"
+            )
+        p = Path(stripped)
+        if p.is_absolute() or ".." in p.parts:
+            raise ValueError(
+                f"adr_path must be a relative subpath with no traversal, got: {adr_path!r}"
+            )
+        self._local_path = local_path
+        self._adr_path = stripped
+
+    @property
+    def adr_dir(self) -> Path:
+        """Absolute path to the ADR subdirectory inside the central repo."""
+        return self._local_path / self._adr_path
+
+    def get_matching_adr_files(self, repo_name: str) -> list[Path]:
+        """Return ADR files from the central repo that match repo_name.
+
+        A file matches if its applies_to frontmatter field matches repo_name
+        by name (short name, full org/repo, list, or wildcard "*").
+
+        Args:
+            repo_name: Repository name to match against applies_to.
+                       Can be short ("build-service") or full ("org/build-service").
+
+        Returns:
+            Sorted list of matching Path objects. Returns [] if local_path
+            does not exist or the adr directory is missing/unreadable.
+        """
+        if not self._local_path.exists():
+            return []
+
+        adr_dir = self.adr_dir
+        if not adr_dir.is_dir():
+            return []
+
+        try:
+            md_files = sorted(
+                p for p in adr_dir.iterdir() if p.suffix == ".md" and p.is_file()
+            )
+        except OSError:
+            return []
+
+        matched = []
+        for f in md_files:
+            try:
+                content = f.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            fm = parse_frontmatter(content)
+            if fm is None:
+                continue
+            applies_to = fm.get("applies_to")
+            if applies_to is None:
+                continue
+            if _applies_to_matches(applies_to, repo_name):
+                matched.append(f)
+
+        return matched

--- a/src/agentready/assessors/code_quality.py
+++ b/src/agentready/assessors/code_quality.py
@@ -877,7 +877,7 @@ class StructuredLoggingAssessor(BaseAssessor):
             tier=self.tier,
             description="Logging in structured format (JSON) with consistent fields",
             criteria="Structured logging library configured (structlog, winston, zap)",
-            default_weight=0.02,
+            default_weight=0.01,
         )
 
     def is_applicable(self, repository: Repository) -> bool:

--- a/src/agentready/assessors/documentation.py
+++ b/src/agentready/assessors/documentation.py
@@ -11,6 +11,7 @@ from ..models.attribute import Attribute
 from ..models.finding import Citation, Finding, Remediation
 from ..models.repository import Repository
 from ..utils.subprocess_utils import safe_subprocess_run
+from .adr_sources import CentralAdrSource
 from .base import BaseAssessor
 
 
@@ -566,7 +567,7 @@ black .
 class ArchitectureDecisionsAssessor(BaseAssessor):
     """Assesses presence and quality of Architecture Decision Records (ADRs).
 
-    Tier 3 Important (3% weight) - ADRs provide historical context for
+    Tier 3 Important (1% weight) - ADRs provide historical context for
     architectural decisions, helping AI understand "why" choices were made.
     """
 
@@ -587,7 +588,7 @@ class ArchitectureDecisionsAssessor(BaseAssessor):
             tier=self.tier,
             description="Lightweight documents capturing architectural decisions",
             criteria="ADR directory with documented decisions",
-            default_weight=0.03,
+            default_weight=0.01,
         )
 
     def assess(self, repository: Repository) -> Finding:
@@ -651,6 +652,12 @@ class ArchitectureDecisionsAssessor(BaseAssessor):
                     pass  # root unreadable — adr_dir stays None, fail finding follows
 
         if not adr_dir:
+            # Check for central ADR repo configured via adr_source config.
+            # If the org maintains ADRs centrally, the repo still gets full credit.
+            central_finding = self._check_central_adr_source(repository)
+            if central_finding is not None:
+                return central_finding
+
             partial_score, partial_evidence = self._check_agent_file_adr_summary(
                 repository
             )
@@ -689,6 +696,11 @@ class ArchitectureDecisionsAssessor(BaseAssessor):
         adr_count = len(adr_files)
 
         if adr_count == 0:
+            # An empty local ADR placeholder should not penalise repos that
+            # rely on a central ADR source — check central config first.
+            central_finding = self._check_central_adr_source(repository)
+            if central_finding is not None:
+                return central_finding
             return Finding(
                 attribute=self.attribute,
                 status="fail",
@@ -737,6 +749,87 @@ class ArchitectureDecisionsAssessor(BaseAssessor):
             score=total_score,
             measured_value=f"{adr_count} ADRs",
             threshold="≥3 ADRs with template",
+            evidence=evidence,
+            remediation=self._create_remediation() if status == "fail" else None,
+            error_message=None,
+        )
+
+    def _check_central_adr_source(self, repository: Repository) -> "Finding | None":
+        """Return a Finding if a central ADR source is configured.
+
+        When an organisation maintains ADRs in a dedicated central repository
+        (configured via config.adr_source), the assessed repo should receive
+        full credit for architecture_decisions even though it has no local ADR dir.
+
+        Returns:
+            Passing Finding: central repo is reachable and has applicable ADRs.
+            Skipped Finding: central repo is configured but the path or subdir
+                             cannot be read (degrade gracefully, not a FAIL).
+            None: adr_source is not configured, or is configured but has no ADRs
+                  that match this repo (caller falls through to local checks).
+        """
+        if repository.config is None:
+            return None
+        adr_source = repository.config.adr_source
+        if not adr_source:
+            return None
+
+        local_path = Path(adr_source.repo)
+        if not local_path.exists():
+            return Finding.skipped(
+                self.attribute,
+                f"Central ADR repo not found at configured path: {local_path}",
+            )
+
+        source = CentralAdrSource(local_path=local_path, adr_path=adr_source.path)
+
+        if not source.adr_dir.is_dir():
+            return Finding.skipped(
+                self.attribute,
+                f"Central ADR subdirectory missing: {source.adr_dir}",
+            )
+
+        # Explicitly verify the directory is readable before delegating.
+        # get_matching_adr_files swallows OSError and returns [], which would
+        # cause a misleading None/fall-through rather than a skipped finding.
+        try:
+            list(source.adr_dir.iterdir())
+        except OSError:
+            return Finding.skipped(
+                self.attribute,
+                f"Central ADR directory is not readable: {source.adr_dir}",
+            )
+
+        matched = source.get_matching_adr_files(repository.name)
+        if not matched:
+            return None
+
+        # Score central ADRs using the same formula as local ADRs so that a
+        # repo with 1 central ADR is not auto-passed at 100 points.
+        adr_count = len(matched)
+        dir_score = 40  # "directory" credit: central repo is configured and reachable
+        count_score = min(adr_count * 8, 40)
+        template_score = self._check_template_compliance(matched[:3])
+        total_score = dir_score + count_score + template_score
+        status = "pass" if total_score >= 75 else "fail"
+
+        evidence = [
+            f"Central ADR repository: {source.adr_dir}",
+            f"{adr_count} ADR(s) in central repo apply to {repository.name}",
+        ]
+        if self._has_consistent_naming(matched):
+            evidence.append("Consistent naming pattern detected")
+        if template_score > 0:
+            evidence.append(
+                f"Sampled {min(adr_count, 3)} ADRs: template compliance {template_score}/20"
+            )
+
+        return Finding(
+            attribute=self.attribute,
+            status=status,
+            score=float(total_score),
+            measured_value=f"{adr_count} central ADR(s)",
+            threshold="ADR directory with decisions",
             evidence=evidence,
             remediation=self._create_remediation() if status == "fail" else None,
             error_message=None,
@@ -1299,7 +1392,7 @@ function calculateDiscount(price, discountPercent) {
 class OpenAPISpecsAssessor(BaseAssessor):
     """Assesses presence and quality of OpenAPI specification.
 
-    Tier 3 Important (3% weight) - Machine-readable API documentation
+    Tier 3 Important (2% weight) - Machine-readable API documentation
     enables AI to generate client code, tests, and integration code.
     """
 
@@ -1320,7 +1413,7 @@ class OpenAPISpecsAssessor(BaseAssessor):
             tier=self.tier,
             description="Machine-readable API documentation in OpenAPI format",
             criteria="OpenAPI 3.x spec with complete endpoint documentation",
-            default_weight=0.03,
+            default_weight=0.02,
         )
 
     def is_applicable(self, repository: Repository) -> bool:

--- a/src/agentready/assessors/patterns.py
+++ b/src/agentready/assessors/patterns.py
@@ -474,7 +474,7 @@ class ProgressiveDisclosureAssessor(BaseAssessor):
             tier=self.tier,
             description="Path-scoped rules and skills for large repos",
             criteria="Component-level context files for repos >50K lines",
-            default_weight=0.02,
+            default_weight=0.01,
         )
 
     LOC_THRESHOLD = 50000

--- a/src/agentready/data/default-weights.yaml
+++ b/src/agentready/data/default-weights.yaml
@@ -1,6 +1,6 @@
 # Default Tier-Based Weight Distribution
 #
-# This file defines the default weights for all 27 attributes.
+# This file defines the default weights for all 28 attributes.
 # Weights are based on evidence from ETH Zurich (Feb 2026), Anthropic,
 # Red Hat best practices (April 2026), and Cursor agent guidelines.
 #
@@ -9,7 +9,7 @@
 #
 # Tier 1 (Essential):  58% total (9 attributes)
 # Tier 2 (Critical):   27% total (3% each, 9 attributes)
-# Tier 3 (Important):  13% total (varies, 7 attributes)
+# Tier 3 (Important):  13% total (varies, 8 attributes)
 # Tier 4 (Advanced):    2% total (1% each, 2 attributes)
 # TOTAL:              100% (sum to 1.0)
 #
@@ -30,6 +30,11 @@
 # - Added threat_model (T3, 2%): structured threat model documentation
 # - Reduced test_execution (12% -> 11%), architecture_decisions (3% -> 2%),
 #   structured_logging (2% -> 1%), openapi_specs (3% -> 2%) to fund new weights
+#
+# Changes in v2.3.0 (feat/adr-frontmatter-central-repo):
+# - Added adr_frontmatter_completeness (T3, 2%): ADR structured-metadata coverage
+# - Reduced architecture_decisions (2% -> 1%) to fund new weight
+# - Reduced progressive_disclosure (2% -> 1%) to fund new weight
 
 # Tier 1 (Essential) - 58% total weight
 test_execution: 0.11                # 5.1 - Test Execution & Coverage
@@ -53,12 +58,13 @@ separation_of_concerns: 0.03        # 4.2 - Separation of Concerns
 pattern_references: 0.03            # 17.1 - Pattern References for Common Changes
 design_intent: 0.03                 # 17.2 - Design Intent Documentation (moved from T3)
 
-# Tier 3 (Important) - 13% total weight (7 attributes)
-architecture_decisions: 0.02        # 2.3 - Architecture Decision Records
+# Tier 3 (Important) - 13% total weight (8 attributes)
+architecture_decisions: 0.01        # 2.3 - Architecture Decision Records
+adr_frontmatter_completeness: 0.02  # 2.4 - ADR Frontmatter Completeness
 openapi_specs: 0.02                 # 10.1 - OpenAPI/Swagger Specifications
 cyclomatic_complexity: 0.02         # 3.1 - Cyclomatic Complexity Thresholds
 structured_logging: 0.01            # 9.2 - Structured Logging
-progressive_disclosure: 0.02        # 17.3 - Progressive Disclosure (moved from T4)
+progressive_disclosure: 0.01        # 17.3 - Progressive Disclosure (moved from T4)
 architectural_boundaries: 0.02      # B.1 - Architectural Boundary Lint Rules (ADR)
 threat_model: 0.02                  # B.2 - Threat Model Documentation (ADR)
 

--- a/src/agentready/models/config.py
+++ b/src/agentready/models/config.py
@@ -8,6 +8,50 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from ..utils.security import validate_path
 
 
+class AdrSourceConfig(BaseModel):
+    """Typed configuration for a central ADR repository.
+
+    Attributes:
+        repo: Absolute path to a locally cloned central ADR repository.
+        path: Relative subpath within repo containing ADR .md files (default "ADR").
+              Must be a relative path with no traversal components.
+    """
+
+    repo: Annotated[
+        str, Field(description="Absolute path to the locally cloned central ADR repo")
+    ]
+    path: Annotated[
+        str,
+        Field(default="ADR", description="Relative subpath within repo (e.g. 'ADR')"),
+    ]
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("path")
+    @classmethod
+    def validate_path_is_relative(cls, v: str) -> str:
+        """Reject empty, absolute, or traversal-containing path values."""
+        stripped = v.rstrip("/")
+        if not stripped:
+            raise ValueError(
+                f"adr_source.path must be a non-empty relative path, got: {v!r}"
+            )
+        p = Path(stripped)
+        if p.is_absolute():
+            raise ValueError(f"adr_source.path must be a relative path, got: {v!r}")
+        if ".." in p.parts:
+            raise ValueError(f"adr_source.path must not contain '..', got: {v!r}")
+        return stripped
+
+    @field_validator("repo")
+    @classmethod
+    def validate_repo_nonempty(cls, v: str) -> str:
+        """Reject empty repo strings."""
+        if not v.strip():
+            raise ValueError("adr_source.repo must not be empty")
+        return v
+
+
 class Config(BaseModel):
     """User configuration for customizing assessment behavior.
 
@@ -21,6 +65,7 @@ class Config(BaseModel):
         output_dir: Custom output directory (None uses default .agentready/)
         report_theme: Theme name for HTML reports (default, dark, light, etc.)
         custom_theme: Custom theme colors (overrides report_theme if provided)
+        adr_source: Central ADR repository config (repo path + relative ADR subdir)
     """
 
     weights: Annotated[
@@ -55,6 +100,13 @@ class Config(BaseModel):
         Field(
             default=None,
             description="Custom theme colors (str → str color mappings)",
+        ),
+    ]
+    adr_source: Annotated[
+        AdrSourceConfig | None,
+        Field(
+            default=None,
+            description="Central ADR repository config (repo path + relative ADR subdir)",
         ),
     ]
 

--- a/tests/unit/test_adr_central_source.py
+++ b/tests/unit/test_adr_central_source.py
@@ -1,0 +1,280 @@
+"""Tests for LocalAdrSource and CentralAdrSource."""
+
+from pathlib import Path
+
+from agentready.assessors.adr_sources import CentralAdrSource, LocalAdrSource
+from agentready.models.repository import Repository
+
+
+def _make_repo(tmp_path: Path, *, name: str = "test-repo") -> Repository:
+    """Create a minimal Repository pointing at tmp_path."""
+    (tmp_path / ".git").mkdir()
+    return Repository(
+        path=tmp_path,
+        name=name,
+        url=None,
+        branch="main",
+        commit_hash="abc123",
+        languages={"Go": 100},
+        total_files=5,
+        total_lines=50,
+    )
+
+
+class TestLocalAdrSourceFindAdrDir:
+    def test_returns_none_when_no_adr_dir(self, tmp_path):
+        """Return None when no candidate ADR directory exists."""
+        repo = _make_repo(tmp_path)
+        source = LocalAdrSource()
+        assert source.find_adr_dir(repo) is None
+
+    def test_finds_uppercase_ADR_at_root_first(self, tmp_path):
+        """Return ADR/ (uppercase) when it exists alongside docs/adr/, honoring priority."""
+        repo = _make_repo(tmp_path)
+        adr_dir = tmp_path / "ADR"
+        adr_dir.mkdir()
+        (adr_dir / "0001-init.md").write_text("# ADR 1")
+        # Also create docs/adr/ to confirm priority ordering
+        (tmp_path / "docs" / "adr").mkdir(parents=True)
+        (tmp_path / "docs" / "adr" / "0002-other.md").write_text("# ADR 2")
+
+        source = LocalAdrSource()
+        found = source.find_adr_dir(repo)
+        assert found == adr_dir
+
+    def test_finds_docs_adr_when_no_uppercase_ADR(self, tmp_path):
+        """Return docs/adr/ when ADR/ is absent."""
+        repo = _make_repo(tmp_path)
+        adr_dir = tmp_path / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "0001-init.md").write_text("# ADR 1")
+
+        source = LocalAdrSource()
+        assert source.find_adr_dir(repo) == adr_dir
+
+    def test_finds_root_adr_lowercase(self, tmp_path):
+        """Return adr/ (lowercase) when it is the first matching candidate."""
+        repo = _make_repo(tmp_path)
+        adr_dir = tmp_path / "adr"
+        adr_dir.mkdir()
+        (adr_dir / "0001-init.md").write_text("# ADR 1")
+
+        source = LocalAdrSource()
+        assert source.find_adr_dir(repo) == adr_dir
+
+    def test_finds_decisions_dir(self, tmp_path):
+        """Return decisions/ when it contains .md files."""
+        repo = _make_repo(tmp_path)
+        adr_dir = tmp_path / "decisions"
+        adr_dir.mkdir()
+        (adr_dir / "0001-init.md").write_text("# ADR 1")
+
+        source = LocalAdrSource()
+        assert source.find_adr_dir(repo) == adr_dir
+
+    def test_finds_doc_adr_dir(self, tmp_path):
+        """Return doc/adr/ (singular doc) when it contains .md files."""
+        repo = _make_repo(tmp_path)
+        adr_dir = tmp_path / "doc" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "0001-init.md").write_text("# ADR 1")
+
+        source = LocalAdrSource()
+        assert source.find_adr_dir(repo) == adr_dir
+
+    def test_skips_dir_with_no_md_files(self, tmp_path):
+        """Skip a candidate directory that contains no .md files."""
+        repo = _make_repo(tmp_path)
+        adr_dir = tmp_path / "ADR"
+        adr_dir.mkdir()
+        (adr_dir / "not-an-adr.txt").write_text("ignored")
+        # docs/adr/ has a .md file
+        docs_adr = tmp_path / "docs" / "adr"
+        docs_adr.mkdir(parents=True)
+        (docs_adr / "0001-init.md").write_text("# ADR 1")
+
+        source = LocalAdrSource()
+        assert source.find_adr_dir(repo) == docs_adr
+
+
+class TestLocalAdrSourceGetAdrFiles:
+    def test_returns_md_files_only(self, tmp_path):
+        """Return only .md files, ignoring other extensions."""
+        adr_dir = tmp_path / "ADR"
+        adr_dir.mkdir()
+        (adr_dir / "0001-init.md").write_text("# ADR 1")
+        (adr_dir / "0002-db.md").write_text("# ADR 2")
+        (adr_dir / "README.txt").write_text("ignored")
+
+        source = LocalAdrSource()
+        files = source.get_adr_files(adr_dir)
+        assert len(files) == 2
+        assert all(f.suffix == ".md" for f in files)
+
+    def test_returns_empty_list_for_empty_dir(self, tmp_path):
+        """Return an empty list when the directory has no .md files."""
+        adr_dir = tmp_path / "ADR"
+        adr_dir.mkdir()
+        source = LocalAdrSource()
+        assert source.get_adr_files(adr_dir) == []
+
+
+VALID_ADR_APPLIES_TO_STAR = """\
+---
+status: Implemented
+applies_to: "*"
+---
+# ADR 0001: Applies to all
+"""
+
+VALID_ADR_APPLIES_TO_SHORT = """\
+---
+status: active
+applies_to: build-service
+---
+# ADR 0002: Applies to build-service
+"""
+
+VALID_ADR_APPLIES_TO_FULL = """\
+---
+status: Proposed
+applies_to: konflux-ci/build-service
+---
+# ADR 0003: Applies to full org/repo
+"""
+
+VALID_ADR_APPLIES_TO_LIST = """\
+---
+status: Deprecated
+applies_to:
+  - build-service
+  - release-service
+---
+# ADR 0004: Applies to a list
+"""
+
+VALID_ADR_APPLIES_TO_OTHER = """\
+---
+status: Implemented
+applies_to: other-service
+---
+# ADR 0005: Applies to other-service only
+"""
+
+NO_FRONTMATTER_ADR = """\
+# ADR 0006: No frontmatter
+"""
+
+
+class TestCentralAdrSource:
+    def _make_central_repo(self, tmp_path: Path) -> Path:
+        """Create a fake central ADR repo at tmp_path/central with ADR/ subdir."""
+        central = tmp_path / "central"
+        adr_dir = central / "ADR"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "0001-star.md").write_text(VALID_ADR_APPLIES_TO_STAR)
+        (adr_dir / "0002-short.md").write_text(VALID_ADR_APPLIES_TO_SHORT)
+        (adr_dir / "0003-full.md").write_text(VALID_ADR_APPLIES_TO_FULL)
+        (adr_dir / "0004-list.md").write_text(VALID_ADR_APPLIES_TO_LIST)
+        (adr_dir / "0005-other.md").write_text(VALID_ADR_APPLIES_TO_OTHER)
+        (adr_dir / "0006-nofm.md").write_text(NO_FRONTMATTER_ADR)
+        return central
+
+    def test_wildcard_matches_any_repo(self, tmp_path):
+        """Include ADRs with applies_to '*' regardless of repo name."""
+        central = self._make_central_repo(tmp_path)
+        source = CentralAdrSource(local_path=central, adr_path="ADR")
+        files = source.get_matching_adr_files("totally-different-repo")
+        names = {f.name for f in files}
+        assert "0001-star.md" in names
+
+    def test_short_name_matches_short_applies_to(self, tmp_path):
+        """Include ADRs whose applies_to exactly equals the short repo name."""
+        central = self._make_central_repo(tmp_path)
+        source = CentralAdrSource(local_path=central, adr_path="ADR")
+        files = source.get_matching_adr_files("build-service")
+        names = {f.name for f in files}
+        assert "0002-short.md" in names
+        assert "0005-other.md" not in names
+
+    def test_full_org_repo_matches_full_applies_to(self, tmp_path):
+        """Include ADRs whose applies_to is the full 'org/repo' name."""
+        central = self._make_central_repo(tmp_path)
+        source = CentralAdrSource(local_path=central, adr_path="ADR")
+        files = source.get_matching_adr_files("konflux-ci/build-service")
+        names = {f.name for f in files}
+        assert "0003-full.md" in names
+        assert (
+            "0002-short.md" in names
+        )  # "build-service" matches suffix of "konflux-ci/build-service"
+
+    def test_short_name_also_matches_full_org_repo(self, tmp_path):
+        """Match an 'org/repo' applies_to value using only the short repo name."""
+        central = self._make_central_repo(tmp_path)
+        source = CentralAdrSource(local_path=central, adr_path="ADR")
+        # "build-service" short name should match "konflux-ci/build-service" applies_to
+        files = source.get_matching_adr_files("build-service")
+        names = {f.name for f in files}
+        assert "0003-full.md" in names
+
+    def test_list_applies_to_matches_any_item(self, tmp_path):
+        """Include ADRs whose applies_to list contains the repo name."""
+        central = self._make_central_repo(tmp_path)
+        source = CentralAdrSource(local_path=central, adr_path="ADR")
+        files = source.get_matching_adr_files("release-service")
+        names = {f.name for f in files}
+        assert "0004-list.md" in names
+
+    def test_no_frontmatter_not_included(self, tmp_path):
+        """Exclude ADR files that have no YAML frontmatter block."""
+        central = self._make_central_repo(tmp_path)
+        source = CentralAdrSource(local_path=central, adr_path="ADR")
+        files = source.get_matching_adr_files("build-service")
+        names = {f.name for f in files}
+        assert "0006-nofm.md" not in names
+
+    def test_non_matching_repo_excluded(self, tmp_path):
+        """Only the wildcard ADR is returned for a repo with no specific applies_to."""
+        central = self._make_central_repo(tmp_path)
+        source = CentralAdrSource(local_path=central, adr_path="ADR")
+        files = source.get_matching_adr_files("unknown-service")
+        names = {f.name for f in files}
+        # Only the wildcard should match
+        assert names == {"0001-star.md"}
+
+    def test_missing_local_path_returns_empty(self, tmp_path):
+        """Return an empty list when the central repo path does not exist."""
+        source = CentralAdrSource(
+            local_path=tmp_path / "does-not-exist",
+            adr_path="ADR",
+        )
+        files = source.get_matching_adr_files("build-service")
+        assert files == []
+
+    def test_adr_path_with_trailing_slash(self, tmp_path):
+        """Strip trailing slash from adr_path so directory lookup succeeds."""
+        central = self._make_central_repo(tmp_path)
+        source = CentralAdrSource(local_path=central, adr_path="ADR/")
+        files = source.get_matching_adr_files("build-service")
+        assert len(files) > 0
+
+    def test_missing_adr_dir_returns_empty(self, tmp_path):
+        """Return empty list when local_path exists but the ADR subdir is absent."""
+        central = tmp_path / "central"
+        central.mkdir()  # local_path exists, but "ADR/" subdir does not
+        source = CentralAdrSource(local_path=central, adr_path="ADR")
+        assert source.get_matching_adr_files("build-service") == []
+
+    def test_non_string_applies_to_not_matched(self, tmp_path):
+        """Exclude ADRs whose applies_to is a non-string, non-list value."""
+        central = tmp_path / "central"
+        adr_dir = central / "ADR"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "numeric.md").write_text(
+            "---\nstatus: Implemented\napplies_to: 42\n---\n# ADR\n"
+        )
+        source = CentralAdrSource(local_path=central, adr_path="ADR")
+        files = source.get_matching_adr_files(
+            "42"
+        )  # even if repo_name == str(applies_to), no match
+        assert files == []

--- a/tests/unit/test_adr_frontmatter.py
+++ b/tests/unit/test_adr_frontmatter.py
@@ -1,0 +1,515 @@
+"""Tests for AdrFrontmatterAssessor."""
+
+from pathlib import Path
+
+import pytest
+
+from agentready.assessors.adr_frontmatter import (
+    VALID_STATUSES,
+    AdrFrontmatterAssessor,
+    classify_adr_file,
+    parse_frontmatter,
+    score_from_coverage,
+)
+from agentready.models.config import Config
+from agentready.models.repository import Repository
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_repo(tmp_path: Path, *, name: str = "test-repo") -> Repository:
+    """Create a minimal Repository pointing at tmp_path."""
+    (tmp_path / ".git").mkdir(exist_ok=True)
+    return Repository(
+        path=tmp_path,
+        name=name,
+        url=None,
+        branch="main",
+        commit_hash="abc123",
+        languages={"Go": 100},
+        total_files=5,
+        total_lines=50,
+    )
+
+
+def _write_adr(directory: Path, filename: str, content: str) -> Path:
+    """Write an ADR file into directory, creating it if needed."""
+    directory.mkdir(parents=True, exist_ok=True)
+    p = directory / filename
+    p.write_text(content)
+    return p
+
+
+VALID_FRONTMATTER = """\
+---
+status: Implemented
+applies_to: build-service
+---
+# ADR 0001: Use PostgreSQL
+
+We chose PostgreSQL as our primary database.
+"""
+
+INCOMPLETE_NO_APPLIES_TO = """\
+---
+status: Implemented
+---
+# ADR 0002: Missing applies_to
+"""
+
+INCOMPLETE_INVALID_STATUS = """\
+---
+status: WrongValue
+applies_to: "*"
+---
+# ADR 0003: Bad status
+"""
+
+INCOMPLETE_EMPTY_STATUS = """\
+---
+status: ""
+applies_to: build-service
+---
+# ADR 0004: Empty status
+"""
+
+NO_FRONTMATTER = """\
+# ADR 0005: No Frontmatter
+
+Just a plain markdown file, no YAML block.
+"""
+
+
+# ---------------------------------------------------------------------------
+# parse_frontmatter
+# ---------------------------------------------------------------------------
+
+
+class TestParseFrontmatter:
+    def test_parses_valid_block(self):
+        """Return a dict when a well-formed frontmatter block is present."""
+        result = parse_frontmatter(VALID_FRONTMATTER)
+        assert result == {"status": "Implemented", "applies_to": "build-service"}
+
+    def test_returns_none_when_no_leading_dashes(self):
+        """Return None for content that does not start with ---."""
+        assert parse_frontmatter(NO_FRONTMATTER) is None
+
+    def test_returns_none_when_closing_dashes_missing(self):
+        """Return None when the closing --- delimiter is absent."""
+        content = "---\nstatus: Implemented\n"
+        assert parse_frontmatter(content) is None
+
+    def test_returns_empty_dict_for_empty_frontmatter(self):
+        """Return an empty dict for an --- --- block with no keys."""
+        content = "---\n---\nBody text"
+        assert parse_frontmatter(content) == {}
+
+    def test_returns_none_for_invalid_yaml(self):
+        """Return None when the frontmatter block contains invalid YAML."""
+        content = "---\n: invalid: yaml: [\n---\n"
+        assert parse_frontmatter(content) is None
+
+    def test_applies_to_wildcard_is_parsed(self):
+        """Parse a wildcard applies_to value correctly."""
+        content = '---\nstatus: active\napplies_to: "*"\n---\n'
+        result = parse_frontmatter(content)
+        assert result["applies_to"] == "*"
+
+    def test_returns_none_for_scalar_frontmatter(self):
+        """Return None when the frontmatter block is a bare scalar, not a mapping."""
+        assert parse_frontmatter("---\ntrue\n---\n# Body\n") is None
+
+    def test_returns_none_for_list_frontmatter(self):
+        """Return None when the frontmatter block is a YAML list, not a mapping."""
+        assert parse_frontmatter("---\n- item1\n- item2\n---\n# Body\n") is None
+
+
+# ---------------------------------------------------------------------------
+# classify_adr_file
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyAdrFile:
+    def test_valid_with_both_fields(self, tmp_path):
+        """Return 'valid' when status and applies_to are both present and correct."""
+        p = tmp_path / "0001.md"
+        p.write_text(VALID_FRONTMATTER)
+        assert classify_adr_file(p) == "valid"
+
+    def test_valid_with_wildcard_applies_to(self, tmp_path):
+        """Return 'valid' when applies_to is the wildcard string."""
+        p = tmp_path / "0001.md"
+        p.write_text('---\nstatus: active\napplies_to: "*"\n---\n# ADR\n')
+        assert classify_adr_file(p) == "valid"
+
+    def test_valid_with_list_applies_to(self, tmp_path):
+        """Return 'valid' when applies_to is a non-empty list."""
+        p = tmp_path / "0001.md"
+        p.write_text(
+            "---\nstatus: Proposed\napplies_to:\n  - repo-a\n  - repo-b\n---\n# ADR\n"
+        )
+        assert classify_adr_file(p) == "valid"
+
+    def test_incomplete_missing_applies_to(self, tmp_path):
+        """Return 'incomplete' when applies_to is absent."""
+        p = tmp_path / "0002.md"
+        p.write_text(INCOMPLETE_NO_APPLIES_TO)
+        assert classify_adr_file(p) == "incomplete"
+
+    def test_valid_unfamiliar_status(self, tmp_path):
+        """Return 'valid' for an unfamiliar but non-empty status string.
+
+        VALID_STATUSES is no longer enforced in classification — any non-empty
+        string is accepted so project-specific lifecycle values are not rejected.
+        """
+        p = tmp_path / "0003.md"
+        p.write_text(INCOMPLETE_INVALID_STATUS)
+        assert classify_adr_file(p) == "valid"
+
+    def test_incomplete_empty_status(self, tmp_path):
+        """Return 'incomplete' when status is an empty string."""
+        p = tmp_path / "0004.md"
+        p.write_text(INCOMPLETE_EMPTY_STATUS)
+        assert classify_adr_file(p) == "incomplete"
+
+    def test_no_frontmatter(self, tmp_path):
+        """Return 'no_frontmatter' for a plain markdown file."""
+        p = tmp_path / "0005.md"
+        p.write_text(NO_FRONTMATTER)
+        assert classify_adr_file(p) == "no_frontmatter"
+
+    def test_all_valid_statuses_accepted(self, tmp_path):
+        """Return 'valid' for every status in VALID_STATUSES."""
+        for status in VALID_STATUSES:
+            p = tmp_path / f"adr-{status}.md"
+            p.write_text(f"---\nstatus: {status}\napplies_to: myrepo\n---\n")
+            assert (
+                classify_adr_file(p) == "valid"
+            ), f"Expected 'valid' for status={status}"
+
+    def test_returns_no_frontmatter_for_missing_file(self, tmp_path):
+        """Return 'no_frontmatter' gracefully when the file does not exist."""
+        assert classify_adr_file(tmp_path / "nonexistent.md") == "no_frontmatter"
+
+    def test_incomplete_when_applies_to_is_numeric(self, tmp_path):
+        """Return 'incomplete' when applies_to is a number (not str or list)."""
+        p = tmp_path / "numeric.md"
+        p.write_text("---\nstatus: Implemented\napplies_to: 123\n---\n# ADR\n")
+        assert classify_adr_file(p) == "incomplete"
+
+
+# ---------------------------------------------------------------------------
+# score_from_coverage
+# ---------------------------------------------------------------------------
+
+
+class TestScoreFromCoverage:
+    def test_100_percent_is_pass(self):
+        """100% valid ADRs yields pass with score 100."""
+        status, score = score_from_coverage(10, 10)
+        assert status == "pass"
+        assert score == 100.0
+
+    def test_80_percent_is_pass(self):
+        """80% valid ADRs (the threshold) yields pass with score 100."""
+        status, score = score_from_coverage(8, 10)
+        assert status == "pass"
+        assert score == 100.0
+
+    def test_79_percent_is_partial(self):
+        """79% valid ADRs (just below threshold) yields partial with score 60."""
+        status, score = score_from_coverage(79, 100)
+        assert status == "partial"
+        assert score == 60.0
+
+    def test_50_percent_is_partial(self):
+        """50% valid ADRs (lower partial boundary) yields partial with score 60."""
+        status, score = score_from_coverage(5, 10)
+        assert status == "partial"
+        assert score == 60.0
+
+    def test_49_percent_is_fail(self):
+        """49% valid ADRs (just below partial band) yields fail with score 0."""
+        status, score = score_from_coverage(49, 100)
+        assert status == "fail"
+        assert score == 0.0
+
+    def test_zero_of_zero_is_pass(self):
+        """Zero files yields pass — caller is expected to handle the skip case."""
+        # Edge case: no files → treat as 100% (skip handled upstream)
+        status, score = score_from_coverage(0, 0)
+        assert status == "pass"
+        assert score == 100.0
+
+
+# ---------------------------------------------------------------------------
+# AdrFrontmatterAssessor — integration tests using LocalAdrSource
+# ---------------------------------------------------------------------------
+
+
+class TestAdrFrontmatterAssessorLocal:
+    def test_skips_when_no_adrs(self, tmp_path):
+        """Return skipped finding when no ADR directory exists in the repo."""
+        repo = _make_repo(tmp_path)
+        assessor = AdrFrontmatterAssessor()
+        finding = assessor.assess(repo)
+        assert finding.status == "skipped"
+        assert "No ADR files found" in finding.evidence[0]
+
+    def test_passes_when_all_adrs_valid(self, tmp_path):
+        """Return pass with score 100 when all ADR files have valid frontmatter."""
+        repo = _make_repo(tmp_path)
+        adr_dir = tmp_path / "ADR"
+        adr_dir.mkdir()
+        for i in range(5):
+            (adr_dir / f"000{i}-adr.md").write_text(
+                f"---\nstatus: Implemented\napplies_to: myrepo\n---\n# ADR {i}\n"
+            )
+        assessor = AdrFrontmatterAssessor()
+        finding = assessor.assess(repo)
+        assert finding.status == "pass"
+        assert finding.score == 100.0
+        assert "ADR location:" in finding.evidence[0]
+        assert "5 valid" in finding.evidence[1]
+
+    def test_partial_between_50_and_79_percent(self, tmp_path):
+        """Return fail with score 60 when coverage is in the 50–79% partial band."""
+        repo = _make_repo(tmp_path)
+        adr_dir = tmp_path / "ADR"
+        adr_dir.mkdir()
+        # 6 valid, 4 no-frontmatter = 60%
+        for i in range(6):
+            (adr_dir / f"valid-{i}.md").write_text(
+                '---\nstatus: active\napplies_to: "*"\n---\n# ADR\n'
+            )
+        for i in range(4):
+            (adr_dir / f"plain-{i}.md").write_text("# Just a heading\n")
+        assessor = AdrFrontmatterAssessor()
+        finding = assessor.assess(repo)
+        assert finding.status == "fail"
+        assert finding.score == 60.0
+        assert finding.remediation is not None
+
+    def test_fails_below_50_percent(self, tmp_path):
+        """Return fail with score 0 when coverage is below 50%."""
+        repo = _make_repo(tmp_path)
+        adr_dir = tmp_path / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+        # 3 valid, 7 no-frontmatter = 30%
+        for i in range(3):
+            (adr_dir / f"valid-{i}.md").write_text(
+                "---\nstatus: Deprecated\napplies_to: svc-a\n---\n# ADR\n"
+            )
+        for i in range(7):
+            (adr_dir / f"plain-{i}.md").write_text("# Plain ADR\n")
+        assessor = AdrFrontmatterAssessor()
+        finding = assessor.assess(repo)
+        assert finding.status == "fail"
+        assert finding.score == 0.0
+        assert finding.remediation is not None
+
+    def test_attribute_id_and_tier(self, tmp_path):
+        """Attribute metadata matches expected values for Tier 3 registration."""
+        assessor = AdrFrontmatterAssessor()
+        assert assessor.attribute_id == "adr_frontmatter_completeness"
+        assert assessor.tier == 3
+        assert assessor.attribute.default_weight == 0.02
+        assert assessor.attribute.category == "Documentation Standards"
+
+    def test_evidence_contains_adr_location(self, tmp_path):
+        """Evidence includes the ADR directory path."""
+        repo = _make_repo(tmp_path)
+        adr_dir = tmp_path / "ADR"
+        adr_dir.mkdir()
+        (adr_dir / "0001.md").write_text(
+            "---\nstatus: Proposed\napplies_to: svc-b\n---\n# ADR 1\n"
+        )
+        assessor = AdrFrontmatterAssessor()
+        finding = assessor.assess(repo)
+        assert any("ADR location:" in e for e in finding.evidence)
+
+    def test_measured_value_format(self, tmp_path):
+        """Measured value string uses 'valid/total (pct%)' format."""
+        repo = _make_repo(tmp_path)
+        adr_dir = tmp_path / "ADR"
+        adr_dir.mkdir()
+        for i in range(4):
+            (adr_dir / f"v-{i}.md").write_text(
+                "---\nstatus: active\napplies_to: myrepo\n---\n# ADR\n"
+            )
+        (adr_dir / "bad.md").write_text("# No frontmatter\n")
+        assessor = AdrFrontmatterAssessor()
+        finding = assessor.assess(repo)
+        # 4/5 = 80% → pass
+        assert finding.measured_value is not None
+        assert "4/5" in finding.measured_value
+        assert "80%" in finding.measured_value
+
+
+# ---------------------------------------------------------------------------
+# AdrFrontmatterAssessor — CentralAdrSource integration via config
+# ---------------------------------------------------------------------------
+
+
+class TestAdrFrontmatterAssessorCentral:
+    def _make_central_repo(self, tmp_path: Path) -> Path:
+        """Create a fake central ADR repo with a few ADR files."""
+        central = tmp_path / "central"
+        adr_dir = central / "ADR"
+        adr_dir.mkdir(parents=True)
+        for i in range(3):
+            (adr_dir / f"000{i}-global.md").write_text(
+                f'---\nstatus: Implemented\napplies_to: "*"\n---\n# ADR {i}\n'
+            )
+        (adr_dir / "0003-specific.md").write_text(
+            "---\nstatus: active\napplies_to: my-service\n---\n# ADR specific\n"
+        )
+        (adr_dir / "0004-other.md").write_text(
+            "---\nstatus: active\napplies_to: other-service\n---\n# ADR other\n"
+        )
+        return central
+
+    def _make_repo_with_central_config(
+        self, tmp_path: Path, central_path: Path, repo_name: str = "my-service"
+    ) -> Repository:
+        """Create a Repository configured to use a central ADR source."""
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        (repo_dir / ".git").mkdir()
+        config = Config(
+            adr_source={
+                "repo": str(central_path),
+                "path": "ADR",
+            }
+        )
+        return Repository(
+            path=repo_dir,
+            name=repo_name,
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Go": 100},
+            total_files=5,
+            total_lines=50,
+            config=config,
+        )
+
+    def test_passes_using_central_source(self, tmp_path):
+        """Return pass when all ADRs matched from the central repo are valid."""
+        central = self._make_central_repo(tmp_path)
+        repo = self._make_repo_with_central_config(tmp_path, central)
+        assessor = AdrFrontmatterAssessor()
+        finding = assessor.assess(repo)
+        # 4 files match (3 wildcard + 1 specific), all valid
+        assert finding.status == "pass"
+        assert finding.score == 100.0
+
+    def test_skips_when_central_local_path_missing(self, tmp_path):
+        """Return skipped when the configured central repo path does not exist."""
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        (repo_dir / ".git").mkdir()
+        config = Config(
+            adr_source={
+                "repo": str(tmp_path / "does-not-exist"),
+                "path": "ADR",
+            }
+        )
+        repo = Repository(
+            path=repo_dir,
+            name="my-service",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Go": 100},
+            total_files=5,
+            total_lines=50,
+            config=config,
+        )
+        assessor = AdrFrontmatterAssessor()
+        finding = assessor.assess(repo)
+        assert finding.status == "skipped"
+        assert (
+            "central" in finding.evidence[0].lower()
+            or "not found" in finding.evidence[0].lower()
+        )
+
+    def test_wildcard_adrs_match_any_repo(self, tmp_path):
+        """Return pass when only wildcard ADRs exist and all are valid."""
+        central = self._make_central_repo(tmp_path)
+        # repo name with no specific applies_to but wildcard ADRs exist
+        repo = self._make_repo_with_central_config(
+            tmp_path, central, repo_name="unknown-repo"
+        )
+        assessor = AdrFrontmatterAssessor()
+        finding = assessor.assess(repo)
+        # 3 wildcard ADRs match unknown-repo
+        # They're all valid → pass
+        assert finding.status == "pass"
+
+    def test_skips_when_no_adrs_match_repo(self, tmp_path):
+        """Fall through to local scan when no central ADRs match the repo.
+
+        When adr_source is configured but no ADRs have applies_to for this repo,
+        _assess_central returns None and _assess_local is called instead.
+        With no local ADR dir either the result is a local skipped finding.
+        """
+        central = tmp_path / "central"
+        adr_dir = central / "ADR"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "0001-specific.md").write_text(
+            "---\nstatus: active\napplies_to: other-service\n---\n# ADR\n"
+        )
+        repo = self._make_repo_with_central_config(
+            tmp_path, central, repo_name="my-service"
+        )
+        assessor = AdrFrontmatterAssessor()
+        finding = assessor.assess(repo)
+        # No central match → fall through to local → no local ADRs → skipped
+        assert finding.status == "skipped"
+        assert "No ADR files found" in finding.evidence[0]
+
+    def test_config_rejects_missing_repo(self):
+        """Config raises ValidationError when adr_source.repo is absent."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="repo"):
+            Config(adr_source={"path": "ADR"})  # repo intentionally omitted
+
+    def test_evidence_includes_central_source_info(self, tmp_path):
+        """Evidence includes central repo path and applies_to filter summary."""
+        central = self._make_central_repo(tmp_path)
+        repo = self._make_repo_with_central_config(tmp_path, central)
+        assessor = AdrFrontmatterAssessor()
+        finding = assessor.assess(repo)
+        assert any("central repo" in e for e in finding.evidence)
+        assert any("Filtered by applies_to" in e for e in finding.evidence)
+
+    def test_config_without_adr_source_uses_local(self, tmp_path):
+        """Fall back to LocalAdrSource when Config has no adr_source key."""
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        (repo_dir / ".git").mkdir()
+        adr_dir = repo_dir / "ADR"
+        adr_dir.mkdir()
+        (adr_dir / "0001.md").write_text(
+            "---\nstatus: Implemented\napplies_to: my-service\n---\n# ADR\n"
+        )
+        config = Config()  # no adr_source
+        repo = Repository(
+            path=repo_dir,
+            name="my-service",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Go": 100},
+            total_files=5,
+            total_lines=50,
+            config=config,
+        )
+        assessor = AdrFrontmatterAssessor()
+        finding = assessor.assess(repo)
+        assert finding.status == "pass"

--- a/tests/unit/test_assessors_documentation.py
+++ b/tests/unit/test_assessors_documentation.py
@@ -686,3 +686,120 @@ class TestAgentInstructionsAssessor:
         assert finding.status == "pass"
         assert finding.score == 100.0
         assert not any("Agent access" in e for e in finding.evidence)
+
+
+class TestArchitectureDecisionsAssessorCentralSource:
+    """Test that ArchitectureDecisionsAssessor gives credit for central ADR repos."""
+
+    def _make_repo(self, tmp_path, config=None):
+        """Create a minimal Repository at tmp_path with an optional Config."""
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".git").mkdir(exist_ok=True)
+        from agentready.models.repository import Repository
+
+        return Repository(
+            path=tmp_path,
+            name="build-service",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"Go": 100},
+            total_files=5,
+            total_lines=50,
+            config=config,
+        )
+
+    def test_passes_when_central_adr_source_configured(self, tmp_path):
+        """Return pass when central ADR repo exists with enough well-formed ADRs.
+
+        Scoring mirrors local ADRs: 40 (dir) + count (8/ADR, max 40) + template (max 20).
+        Three ADRs with all four template sections → 40 + 24 + 20 = 84 ≥ 75 → pass.
+        """
+        from agentready.assessors.documentation import ArchitectureDecisionsAssessor
+        from agentready.models.config import Config
+
+        central = tmp_path / "central" / "ADR"
+        central.mkdir(parents=True)
+        # Three ADRs each containing all required template sections (status/context/decision/consequences)
+        full_template = "# Status\nAccepted\n# Context\nWhy.\n# Decision\nWe will.\n# Consequences\nBecause.\n"
+        for i in range(1, 4):
+            (central / f"000{i}.md").write_text(
+                f'---\nstatus: Accepted\napplies_to: "*"\n---\n{full_template}'
+            )
+
+        config = Config(adr_source={"repo": str(tmp_path / "central"), "path": "ADR"})
+        repo = self._make_repo(tmp_path / "repo", config=config)
+
+        finding = ArchitectureDecisionsAssessor().assess(repo)
+        assert finding.status == "pass"
+        assert finding.score >= 75.0
+        assert any("central" in e.lower() for e in finding.evidence)
+
+    def test_skips_when_central_path_missing(self, tmp_path):
+        """Return skipped (not fail) when the configured central repo path does not exist.
+
+        When adr_source is configured but unreachable, the assessor degrades
+        gracefully to a skipped finding rather than falling through to a FAIL.
+        """
+        from agentready.assessors.documentation import ArchitectureDecisionsAssessor
+        from agentready.models.config import Config
+
+        config = Config(
+            adr_source={"repo": str(tmp_path / "nonexistent"), "path": "ADR"}
+        )
+        repo = self._make_repo(tmp_path / "repo", config=config)
+
+        finding = ArchitectureDecisionsAssessor().assess(repo)
+        assert finding.status == "skipped"
+        assert (
+            "not found" in finding.evidence[0].lower()
+            or "nonexistent" in finding.evidence[0]
+        )
+
+    def test_falls_through_when_no_adrs_match_repo(self, tmp_path):
+        """Fall through to fail when central ADRs exist but none match the repo name."""
+        from agentready.assessors.documentation import ArchitectureDecisionsAssessor
+        from agentready.models.config import Config
+
+        central = tmp_path / "central" / "ADR"
+        central.mkdir(parents=True)
+        # ADR only applies to a different service, not the assessed repo
+        (central / "0001.md").write_text(
+            "---\nstatus: Accepted\napplies_to: other-service\n---\n# ADR\n"
+        )
+
+        config = Config(adr_source={"repo": str(tmp_path / "central"), "path": "ADR"})
+        repo = self._make_repo(tmp_path / "repo", config=config)
+
+        finding = ArchitectureDecisionsAssessor().assess(repo)
+        # No ADRs match the repo name → falls through to normal failure path
+        assert finding.status == "fail"
+
+    def test_skips_when_adr_subdir_missing(self, tmp_path):
+        """Return skipped (not fail) when the repo root exists but ADR subdir is absent.
+
+        Configured-but-broken central repos degrade gracefully to skipped,
+        not to a FAIL that would penalise the score.
+        """
+        from agentready.assessors.documentation import ArchitectureDecisionsAssessor
+        from agentready.models.config import Config
+
+        # local_path exists but the ADR subdir does not
+        central = tmp_path / "central"
+        central.mkdir(parents=True)
+
+        config = Config(adr_source={"repo": str(central), "path": "ADR"})
+        repo = self._make_repo(tmp_path / "repo", config=config)
+
+        finding = ArchitectureDecisionsAssessor().assess(repo)
+        assert finding.status == "skipped"
+        assert "subdir" in finding.evidence[0].lower() or "ADR" in finding.evidence[0]
+
+    def test_no_config_still_fails_without_local_adr(self, tmp_path):
+        """Fail with score 0 when no config is set and no local ADR directory exists."""
+        from agentready.assessors.documentation import ArchitectureDecisionsAssessor
+
+        repo = self._make_repo(tmp_path)
+        finding = ArchitectureDecisionsAssessor().assess(repo)
+        assert finding.status == "fail"
+        assert finding.score == 0.0

--- a/tests/unit/test_assessors_patterns.py
+++ b/tests/unit/test_assessors_patterns.py
@@ -608,7 +608,7 @@ class TestProgressiveDisclosureAssessor:
     def test_default_weight(self):
         """Test default weight matches YAML config."""
         assessor = ProgressiveDisclosureAssessor()
-        assert assessor.attribute.default_weight == 0.02
+        assert assessor.attribute.default_weight == 0.01
 
     def test_not_applicable_for_small_repos(self, tmp_path):
         """Test that small repos get not_applicable status."""


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Adds a new `adr_frontmatter_completeness` assessor (Tier 3, 2% weight) that scores repositories on whether ADR files contain structured YAML frontmatter with required `status` and `applies_to` fields. Also adds central ADR repository support so teams that maintain ADRs in a shared repo are not penalised, and fixes `ArchitectureDecisionsAssessor` to respect that same config.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues

<!-- Link related issues here using #issue_number -->

Fixes #512
Fixes #513


## Changes Made

<!-- Detailed list of changes made in this PR -->

- Added `adr_frontmatter_completeness` assessor (`src/agentready/assessors/adr_frontmatter.py`) — scores repos on YAML frontmatter coverage across ADR files; thresholds: ≥80% → pass, 50–79% → partial, <50% → fail
- Added `LocalAdrSource` and `CentralAdrSource` (`src/agentready/assessors/adr_sources.py`) — `LocalAdrSource` discovers ADR directories on the local repo filesystem; `CentralAdrSource` reads ADRs from a locally cloned shared repo and filters by `applies_to` (supports wildcard, short name, full `org/repo`, and list matching)
- Extended `Config` model with `adr_source: dict | None` field for central repo configuration (`repo` + `path` keys)
- Fixed `ArchitectureDecisionsAssessor` (`src/agentready/assessors/documentation.py`) to pass when `adr_source` is configured and the central repo path exists, rather than failing repos that intentionally maintain ADRs centrally
- Registered `AdrFrontmatterAssessor` in `assessors/__init__.py`
- Added `adr_frontmatter_completeness: 0.02` weight to `default-weights.yaml`; rebalanced by reducing `architecture_decisions` (2% → 1%) and `progressive_disclosure` (2% → 1%) to keep total at 1.0


## Testing

<!-- Describe the tests you ran to verify your changes -->

- [X ] Unit tests pass (`pytest`)
- [ ] Integration tests pass
- [ X] Manual testing performed
- [ X] No new warnings or errors

## Checklist

- [ X] My code follows the project's code style
- [X ] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
- [X ] I have added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->

**Central ADR repo config** (`.agentready-config.yaml`):
```yaml
adr_source:
  repo: /path/to/local/clone   # locally cloned central ADR repo
  path: ADR                    # relative path within that repo
```

No network calls are made — the central repo must be locally cloned. The assessor gracefully skips if the path does not exist or no ADRs match the assessed repo's name.

Valid status values cover MADR (Proposed, Accepted, Implementable, Implemented, Replaced, Deprecated, Superseded, Approved) and adr-tools (active, superseded, draft) conventions to accommodate common ADR tooling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `adr_frontmatter_completeness` scoring for ADRs based on YAML `status` and `applies_to`, including remediation guidance.
  * Added centralized ADR lookup via configuration, with repo-aware `applies_to` matching and evidence reporting.
* **Bug Fixes**
  * Architecture Decisions assessment now fully credits centralized ADR matches and correctly skips when centralized ADRs aren’t available.
* **Chores**
  * Rebalanced Tier 3 and other default weights to include the new attribute.
* **Tests**
  * Added unit tests covering frontmatter parsing/classification, local/central discovery, and updated weight expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->