### PR TITLE
feat: recognize bun.lock as a dependency lock file

### DIFF
--- a/src/agentready/assessors/stub_assessors.py
+++ b/src/agentready/assessors/stub_assessors.py
@@ -50,6 +50,7 @@ class DependencyPinningAssessor(BaseAssessor):
             "package-lock.json",  # npm
             "yarn.lock",  # Yarn
             "pnpm-lock.yaml",  # pnpm
+            "bun.lock",  # Bun
             "poetry.lock",  # Poetry
             "Pipfile.lock",  # Pipenv
             "uv.lock",  # uv

--- a/tests/unit/test_assessors_stub.py
+++ b/tests/unit/test_assessors_stub.py
@@ -225,6 +225,30 @@ numpy
         assert "package-lock.json" in finding.measured_value
         assert "Cargo.lock" in finding.measured_value
 
+    def test_bun_lock_file(self, tmp_path):
+        """Test that bun.lock is recognized as a valid lock file."""
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+
+        (tmp_path / "bun.lock").write_text("# bun lockfile\n")
+
+        repo = Repository(
+            path=tmp_path,
+            name="test-repo",
+            url=None,
+            branch="main",
+            commit_hash="abc123",
+            languages={"TypeScript": 100},
+            total_files=10,
+            total_lines=100,
+        )
+
+        assessor = DependencyPinningAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.status == "pass"
+        assert finding.score == 100.0
+        assert "bun.lock" in finding.measured_value
+
     def test_backward_compatibility_alias(self):
         """Test that LockFilesAssessor is an alias for DependencyPinningAssessor."""
         from agentready.assessors.stub_assessors import LockFilesAssessor


### PR DESCRIPTION
## Description

Bun (https://bun.sh) is a JS/TS runtime and package manager whose lockfile `bun.lock` pins exact dependency versions — equivalent to `package-lock.json` or `pnpm-lock.yaml`. Repos using Bun were previously assessed as having **no lock file** (`lock_files` score 0) even though their dependencies are fully reproducible.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

No related issues (no existing Bun-support issue found; see sibling PRs #532, #533, #534).

## Changes Made

- Add `bun.lock` to `strict_lock_files` in `stub_assessors.py`.
- Add unit test `test_bun_lock_file` covering a Bun-based repository.

## Testing

- [x] Unit tests pass (`pytest`) — 178 passed
- [x] Manual testing performed — verified against a real Bun repo (Next.js base template, `lock_files` 0 → 100)
- [x] No new warnings or errors — ruff clean

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Part of a small series adding first-class Bun support to agentready (CI gates, single-file verification, dependency audit).
