### PR TITLE
chore(ci): pass workflow_run PR lookup inputs via env

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -61,7 +61,7 @@ jobs:
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
       - name: Download coverage data
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: coverage-data
           path: coverage-data
@@ -97,7 +97,7 @@ jobs:
           fi
 
       - name: Post coverage comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           PR_COVERAGE: ${{ steps.coverage.outputs.pr_coverage }}
           MAIN_COVERAGE: ${{ steps.coverage.outputs.main_coverage }}

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -26,14 +26,13 @@ jobs:
         id: pr_info
         env:
           GH_TOKEN: ${{ github.token }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          TARGET_REPO: ${{ github.repository }}
         run: |
           # For fork PRs, pull_requests array is empty in workflow_run event
           # Use gh pr view to find the PR number
           # See: https://github.com/orgs/community/discussions/25220
-
-          HEAD_REPO="${{ github.event.workflow_run.head_repository.full_name }}"
-          HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
-          TARGET_REPO="${{ github.repository }}"
 
           echo "Looking for PR from ${HEAD_REPO} branch ${HEAD_BRANCH}"
 

--- a/.github/workflows/leaderboard-comment.yml
+++ b/.github/workflows/leaderboard-comment.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Download validation data
         if: steps.pr_info.outputs.pr_number
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: leaderboard-validation
           path: validation-data
@@ -56,7 +56,7 @@ jobs:
 
       - name: Post validation comment
         if: steps.pr_info.outputs.pr_number
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           TRUSTED_PR_NUMBER: ${{ steps.pr_info.outputs.pr_number }}
         with:

--- a/.github/workflows/leaderboard-comment.yml
+++ b/.github/workflows/leaderboard-comment.yml
@@ -23,11 +23,10 @@ jobs:
         id: pr_info
         env:
           GH_TOKEN: ${{ github.token }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          TARGET_REPO: ${{ github.repository }}
         run: |
-          HEAD_REPO="${{ github.event.workflow_run.head_repository.full_name }}"
-          HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
-          TARGET_REPO="${{ github.repository }}"
-
           if [ "$HEAD_REPO" = "$TARGET_REPO" ]; then
             BRANCH_QUERY="${HEAD_BRANCH}"
           else


### PR DESCRIPTION
## Summary

Pass `workflow_run` PR lookup inputs through step `env:` in the coverage and leaderboard comment workflows, instead of embedding GitHub expressions in the shell script body.

This is a small future-proofing change so those values are treated as data by the runner, not as part of the generated bash text. PR lookup behavior is unchanged: same-repo vs fork `gh pr view` queries still work the same way, and job permissions are unchanged.

## Changes

- `.github/workflows/coverage-comment.yml` — `HEAD_REPO`, `HEAD_BRANCH`, and `TARGET_REPO` come from `env:`
- `.github/workflows/leaderboard-comment.yml` — same pattern

## Test plan

- [ ] Confirm the two workflow YAML files parse and the `pr_info` step still uses quoted shell variables
- [ ] `actionlint` on the updated workflows when available
- [ ] Existing unit smoke tests still pass locally (`111 passed, 3 skipped` on `tests/unit/cli/test_main.py` and `tests/unit/test_models.py`)


AI-Attribution: AIA PAI Nc Hin R gpt-5.4 v1.0
AI-Interpretation: https://aiattribution.github.io/statements/AIA-PAI-Nc-Hin-R-?model=gpt-5.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the reliability and security of automated coverage and leaderboard comments.
  * Preserved existing pull request, branch, and repository lookup behavior.
  * Automated comment workflows now use more consistent configuration and securely verified actions.
  * No changes were made to the content or behavior of generated comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->