### PR TITLE
fix(assessors): recognize Go package dirs, versioned golangci-lint, and gofmt -l

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -707,7 +707,10 @@ The assessor looks for patterns like:
 - `eslint <file>` (lint)
 - `tsc --noEmit <file>` (type-check)
 - `golangci-lint run <file>` (lint)
+- `golangci-lint-vX.Y.Z run ./pkg/foo/` (lint; versioned binary + Go package dir)
+- `gofmt <file>` / `gofmt -l file.go` (lint)
 - `go vet <file>` (type-check / static analysis)
+- `go vet ./pkg/foo/` (type-check; Go package dir)
 - `yamllint <file>` (lint)
 - `shellcheck <file>` (lint)
 - `bash -n <file>` (shell syntax check / type-check analog)
@@ -718,7 +721,7 @@ Common passing pairs by ecosystem:
 - **Shell**: `shellcheck` + `bash -n`
 - **YAML-only repos**: `yamllint` alone is insufficient; a second recognized command is still required
 
-Commands must target a **single file path** (not `./...` or a directory).
+Commands must target a **single file path**, or for Go a **package directory** such as `./pkg/foo/` (not `./...` or `.`).
 
 #### Remediation
 

--- a/src/agentready/assessors/verification.py
+++ b/src/agentready/assessors/verification.py
@@ -38,7 +38,9 @@ class SingleFileVerificationAssessor(BaseAssessor):
 
     # Patterns that suggest single-file lint/type-check commands.
     # Each entry is (regex, category) where category is "lint" or "typecheck".
-    # The lookahead (?=\s*(?:[`\n]|$)) anchors the file path as the final
+    # Most patterns require a file with an extension. Go also accepts a
+    # package directory (`./pkg/foo/`), but not `./...` or `.`.
+    # The lookahead (?=\s*(?:[`\n]|$)) anchors the path as the final
     # token — only backtick (end of inline code), newline, or end-of-string
     # may follow, preventing multi-file invocations from matching.
     SINGLE_FILE_PATTERNS = [
@@ -49,14 +51,20 @@ class SingleFileVerificationAssessor(BaseAssessor):
         (r"flake8\s+(?!-)[\w./\-]*\.\w{1,10}(?=\s*(?:[`\n]|$))", "lint"),
         (r"rubocop\s+(?!-)[\w./\-]*\.\w{1,10}(?=\s*(?:[`\n]|$))", "lint"),
         (r"golangci-lint\s+run\s+(?!-)[\w./\-]*\.\w{1,10}(?=\s*(?:[`\n]|$))", "lint"),
+        (
+            r"golangci-lint(?:-v\d+\.\d+\.\d+)?\s+run\s+\./(?:[\w\-]+/)*[\w\-]+/?(?=\s*(?:[`\n]|$))",
+            "lint",
+        ),
         (r"black\s+--check\s+(?!-)[\w./\-]*\.\w{1,10}(?=\s*(?:[`\n]|$))", "lint"),
         (r"prettier\s+--check\s+(?!-)[\w./\-]*\.\w{1,10}(?=\s*(?:[`\n]|$))", "lint"),
         (r"gofmt\s+(?!-)[\w./\-]*\.\w{1,10}(?=\s*(?:[`\n]|$))", "lint"),
+        (r"gofmt\s+-l\s+(?!-)[\w./\-]*\.\w{1,10}(?=\s*(?:[`\n]|$))", "lint"),
         (r"yamllint\s+(?!-)[\w./\-]*\.\w{1,10}(?=\s*(?:[`\n]|$))", "lint"),
         (r"shellcheck\s+(?!-)[\w./\-]*\.\w{1,10}(?=\s*(?:[`\n]|$))", "lint"),
         # Type check single file patterns
         (r"mypy\s+(?!-)[\w./\-]*\.\w{1,10}(?=\s*(?:[`\n]|$))", "typecheck"),
         (r"go\s+vet\s+(?!-)[\w./\-]*\.\w{1,10}(?=\s*(?:[`\n]|$))", "typecheck"),
+        (r"go\s+vet\s+\./(?:[\w\-]+/)*[\w\-]+/?(?=\s*(?:[`\n]|$))", "typecheck"),
         (r"bash\s+-n\s+(?!-)[\w./\-]*\.\w{1,10}(?=\s*(?:[`\n]|$))", "typecheck"),
         (r"pyright\s+(?!-)[\w./\-]*\.\w{1,10}(?=\s*(?:[`\n]|$))", "typecheck"),
         (r"tsc\s+--noEmit\s+(?!-)[\w./\-]*\.\w{1,10}(?=\s*(?:[`\n]|$))", "typecheck"),

--- a/tests/unit/test_assessors_verification.py
+++ b/tests/unit/test_assessors_verification.py
@@ -158,6 +158,50 @@ class TestSingleFileVerificationAssessor:
 
         assert finding.score == 0.0
 
+    def test_recognizes_versioned_golangci_lint(self, tmp_path):
+        """Test that versioned golangci-lint on a Go package dir counts as lint."""
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text("Run `./bin/golangci-lint-v2.11.4 run ./pkg/notifier/`\n")
+
+        repo = self._make_repo(tmp_path)
+        assessor = SingleFileVerificationAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.score >= 50.0
+
+    def test_recognizes_go_vet_package_dir(self, tmp_path):
+        """Test that go vet on a Go package dir counts as typecheck."""
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text("Type check: `go vet ./pkg/notifier/`\n")
+
+        repo = self._make_repo(tmp_path)
+        assessor = SingleFileVerificationAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.score >= 50.0
+
+    def test_go_vet_dot_does_not_match(self, tmp_path):
+        """Test that go vet . is not recognized as scoped typecheck."""
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text("Run `go vet .` for static analysis.\n")
+
+        repo = self._make_repo(tmp_path)
+        assessor = SingleFileVerificationAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.score == 0.0
+
+    def test_recognizes_gofmt_dash_l(self, tmp_path):
+        """Test that gofmt -l on a file counts as lint."""
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text("Lint: `gofmt -l main.go`\n")
+
+        repo = self._make_repo(tmp_path)
+        assessor = SingleFileVerificationAssessor()
+        finding = assessor.assess(repo)
+
+        assert finding.score >= 50.0
+
     def test_recognizes_yamllint(self, tmp_path):
         """Test that yamllint pattern is recognized as lint."""
         claude_md = tmp_path / "CLAUDE.md"


### PR DESCRIPTION
Go agent docs fail today because commands target packages, pin versioned binaries, or use gofmt -l. Keep existing file.go patterns.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues

<!-- Link related issues here using #issue_number -->

Fixes #
Relates to #537

## Changes Made

<!-- Detailed list of changes made in this PR -->

- Match Go package dirs (./pkg/foo/) for golangci-lint run and go vet, including versioned golangci-lint-vX.Y.Z; still reject . and ./...
- Match gofmt -l file.go; keep existing file.go patterns
-

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ x ] Unit tests pass (`pytest`)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] No new warnings or errors

## Checklist

- [ x ] My code follows the project's code style
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded verification support for common Go tooling commands, including `golangci-lint`, `gofmt`, and `go vet`.
  * Go verification commands can now target package directories in addition to individual files.

* **Documentation**
  * Updated verification criteria to reflect the newly recognized Go command patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->