### PR TITLE
docs: describe partial-credit pass range for dependency_security

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -778,7 +778,7 @@ The assessor checks for recognized security tools:
 - **Semgrep** (multi-language SAST) — 15 pts
 - **SECURITY.md** present — 5 pts bonus
 
-**Pass threshold**: 60 points.
+**Pass threshold**: 60+ points is a full pass. Scores of 30-59 still pass with partial credit, but the finding includes remediation guidance for adding more scanning tools. Scores below 30 fail.
 
 **Tools checked**: pip-audit, safety, dependabot, snyk, trivy, grype, osvscanner, bandit (Python); npm audit, yarn audit (JavaScript/TypeScript); CodeQL, Semgrep, gitleaks, detect-secrets (multi-language).
 


### PR DESCRIPTION
## Summary

The `dependency_security` entry in `docs/attributes.md` stated a flat "Pass threshold: 60 points," but `DependencySecurityAssessor` in `src/agentready/assessors/security.py` passes any score of 30 or higher. Scores of 30-59 are partial-credit passes with remediation guidance attached to the finding, and only scores below 30 fail.

This updates the docs to describe the actual behavior:

- 60+ points: full pass
- 30-59 points: pass with partial credit, remediation guidance included
- Below 30: fail

Docs-only change; no assessor behavior is modified.

This PR was created by Bill Murdock with assistance from Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Dependency Security scoring guidance to clarify full-pass, partial-credit, and failing score ranges.
  * Added remediation guidance for scores receiving partial credit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->